### PR TITLE
Refactoring of microphone widget from activity into own service

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -57,6 +57,10 @@
             android:label="@string/title_activity_openhabinfo" >
         </activity>
         <activity android:name="de.duenndns.ssl.MemorizingActivity" />
+        <service
+            android:name=".core.OpenHABVoiceService"
+            android:exported="false">
+        </service>
         <receiver
             android:name="org.openhab.habdroid.core.GcmBroadcastReceiver"
             android:permission="com.google.android.c2dm.permission.SEND">

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
@@ -1,0 +1,218 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.habdroid.core;
+
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.os.Handler;
+import android.os.Looper;
+import android.preference.PreferenceManager;
+import android.speech.RecognizerIntent;
+import android.util.Log;
+import android.widget.Toast;
+
+import com.loopj.android.http.AsyncHttpResponseHandler;
+
+import org.apache.http.entity.StringEntity;
+import org.openhab.habdroid.R;
+import org.openhab.habdroid.util.Constants;
+import org.openhab.habdroid.util.ContinuingIntentService;
+import org.openhab.habdroid.util.MyAsyncHttpClient;
+
+import java.io.UnsupportedEncodingException;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+/**
+ * This service handles voice commands and sends them to OpenHAB.
+ * It will use the openHAB base URL if passed in the intent's extra,
+ * or else use the {@link OpenHABTracker} to discover openHAB itself.
+ */
+public class OpenHABVoiceService extends ContinuingIntentService implements OpenHABTrackerReceiver {
+
+    private static final String TAG = OpenHABVoiceService.class.getSimpleName();
+    public static final String OPENHAB_BASE_URL_EXTRA = "openHABBaseUrl";
+
+    private String mOpenHABBaseUrl;
+    private MyAsyncHttpClient mAsyncHttpClient;
+
+    private OpenHABTracker mOpenHABTracker;
+    private Queue<Intent> mBufferedIntents;
+
+
+    public OpenHABVoiceService() {
+        super(TAG);
+    }
+
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        Log.d(TAG, "onCreate()");
+
+        mBufferedIntents = new LinkedList<Intent>();
+        initHttpClient();
+    }
+
+    private void initHttpClient() {
+        SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(this);
+        String username = mSettings.getString(Constants.PREFERENCE_USERNAME, null);
+        String password = mSettings.getString(Constants.PREFERENCE_PASSWORD, null);
+        mAsyncHttpClient = new MyAsyncHttpClient(this);
+        mAsyncHttpClient.setBasicAuth(username, password);
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        Log.d(TAG, "onHandleIntent()");
+        bufferIntent(intent);
+        if (intent.hasExtra(OPENHAB_BASE_URL_EXTRA)) {
+            Log.d(TAG, "openHABBaseUrl passed as Intent");
+            onOpenHABTracked(intent.getStringExtra(OPENHAB_BASE_URL_EXTRA), null);
+        } else if (mOpenHABTracker == null) {
+            Log.d(TAG, "No openHABBaseUrl passed, starting OpenHABTracker");
+            mOpenHABTracker = new OpenHABTracker(OpenHABVoiceService.this, getString(R.string.openhab_service_type), false);
+            mOpenHABTracker.start();
+        }
+    }
+
+    /**
+     * Buffers the {@link Intent} to be processed later when openHABBaseUrl has been determined by {@link OpenHABTracker}.
+     *
+     * Usually, the discovery of the openHABBaseUrl is fast enough, so there will be only one intent in the buffer
+     * when the buffer is processed and this service is stopped.
+     * However, it is not guaranteed that this service is only called once before openHABBaseUrl can be discovered.
+     * Therefore all intents are buffered and later this buffer will be processed.
+     *
+     * @param intent The {@link Intent} to be buffered.
+     */
+    private void bufferIntent(Intent intent) {
+        mBufferedIntents.add(intent);
+    }
+
+    @Override
+    public void onOpenHABTracked(String baseUrl, String message) {
+        Log.d(TAG, "onOpenHABTracked(): " + baseUrl);
+        mOpenHABBaseUrl = baseUrl;
+        while (!mBufferedIntents.isEmpty()) {
+            processVoiceIntent(mBufferedIntents.poll());
+        }
+        Log.d(TAG, "Stopping service for start ID " + getLastStartId());
+        stopSelf(getLastStartId());
+    }
+
+    @Override
+    public void onError(String error) {
+        showToast(error);
+        Log.d(TAG, "onError(): " + error);
+        stopSelf();
+    }
+
+
+    private void processVoiceIntent(Intent data) {
+        Log.d(TAG, "processVoiceIntent()");
+
+        String voiceCommand = extractVoiceCommand(data);
+        if (!voiceCommand.isEmpty()) {
+            if (mOpenHABBaseUrl != null) {
+                sendItemCommand("VoiceCommand", voiceCommand);
+            } else {
+                Log.w(TAG, "Couldn't determine OpenHAB URL");
+                showToast("Couldn't determine OpenHAB URL");
+            }
+        }
+    }
+
+
+    private String extractVoiceCommand(Intent data) {
+        String voiceCommand = "";
+        List<String> textMatchList = data.getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS);
+        if (!textMatchList.isEmpty()) {
+            voiceCommand = textMatchList.get(0);
+        }
+        Log.i(TAG, "Recognized text: " + voiceCommand);
+        showToast(getString(R.string.info_voice_recognized_text, voiceCommand));
+        return voiceCommand;
+    }
+
+
+    private void sendItemCommand(final String itemName, final String command) {
+        Log.d(TAG, "sendItemCommand(): itemName=" + itemName + ", command=" + command);
+        try {
+            performHttpPost(itemName, new StringEntity(command, "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            Log.e(TAG, "Unable to encode command " + command, e);
+        }
+    }
+
+    private void performHttpPost(final String itemName, final StringEntity command) {
+        /* Call MyAsyncHttpClient on the main UI thread in order to retrieve the callbacks correctly.
+         * If calling MyAsyncHttpClient directly, the following would happen:
+         * (1) MyAsyncHttpClient performs the HTTP post asynchronously
+         * (2) OpenHABVoiceService stops because all intents have been handled
+         * (3) MyAsyncHttpClient tries to call onSuccess() or onFailure(), which is not possible
+         *     anymore because OpenHABVoiceService is already stopped/destroyed.
+         */
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                mAsyncHttpClient.post(OpenHABVoiceService.this, mOpenHABBaseUrl + "rest/items/" + itemName,
+                        command, "text/plain;charset=UTF-8", new AsyncHttpResponseHandler() {
+                            @Override
+                            public void onSuccess(String response) {
+                                Log.d(TAG, "Command was sent successfully");
+                            }
+
+                            @Override
+                            public void onFailure(Throwable error, String errorResponse) {
+                                Log.e(TAG, "Got command error " + errorResponse, error);
+                            }
+                        });
+            }
+        });
+    }
+
+
+    @Override
+    public void onDestroy() {
+        Log.d(TAG, "onDestroy()");
+        if (mOpenHABTracker != null) {
+            mOpenHABTracker.stop();
+        }
+        super.onDestroy();
+    }
+
+    /**
+     * Displays the given message as a toast
+     *
+     * @param message The message to be displayed.
+     */
+    private void showToast(final String message) {
+        // Display toast on main looper because OpenHABVoiceService might be destroyed
+        // before to toast has finished displaying
+        new Handler(Looper.getMainLooper()).post(new Runnable() {
+            @Override
+            public void run() {
+                Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG).show();
+            }
+        });
+    }
+
+    @Override
+    public void onBonjourDiscoveryStarted() {
+        Log.d(TAG, "onBonjourDiscoveryStarted()");
+    }
+
+    @Override
+    public void onBonjourDiscoveryFinished() {
+        Log.d(TAG, "onBonjourDiscoveryFinished()");
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -61,6 +61,7 @@ import org.openhab.habdroid.core.NetworkConnectivityInfo;
 import org.openhab.habdroid.core.NotificationDeletedBroadcastReceiver;
 import org.openhab.habdroid.core.OpenHABTracker;
 import org.openhab.habdroid.core.OpenHABTrackerReceiver;
+import org.openhab.habdroid.core.OpenHABVoiceService;
 import org.openhab.habdroid.model.OpenHABLinkedPage;
 import org.openhab.habdroid.model.OpenHABSitemap;
 import org.openhab.habdroid.ui.drawer.OpenHABDrawerAdapter;
@@ -84,7 +85,6 @@ public class OpenHABMainActivity extends FragmentActivity implements OnWidgetSel
     // Logging TAG
     private static final String TAG = "MainActivity";
     // Activities request codes
-    private static final int VOICE_RECOGNITION_REQUEST_CODE = 1001;
     private static final int SETTINGS_REQUEST_CODE = 1002;
     private static final int WRITE_NFC_TAG_REQUEST_CODE = 1003;
     private static final int INFO_REQUEST_CODE = 1004;
@@ -121,8 +121,6 @@ public class OpenHABMainActivity extends FragmentActivity implements OnWidgetSel
     private static MyAsyncHttpClient mAsyncHttpClient;
     // NFC Launch data
     private String mNfcData;
-    // Voice Launch data
-    private String mVoiceData;
     // Pending NFC page
     private String mPendingNfcPage;
     // Drawer Layout
@@ -240,22 +238,11 @@ public class OpenHABMainActivity extends FragmentActivity implements OnWidgetSel
                 if (getIntent().getAction().equals("android.nfc.action.NDEF_DISCOVERED")) {
                     Log.d(TAG, "This is NFC action");
                     if (getIntent().getDataString() != null) {
-
-
-
-
                         Log.d(TAG, "NFC data = " + getIntent().getDataString());
                         mNfcData = getIntent().getDataString();
                     }
                 } else if (getIntent().getAction().equals("org.openhab.notification.selected")) {
                     onNotificationSelected(getIntent());
-                }
-            }else if(getIntent().getExtras() != null){
-                Log.d(TAG, "This is Voice action");
-
-                List<String> results = getIntent().getExtras().getStringArrayList("android.speech.extra.RESULTS");
-                if (!results.isEmpty()) {
-                    mVoiceData = results.get(0);
                 }
             }
         }
@@ -353,9 +340,6 @@ public class OpenHABMainActivity extends FragmentActivity implements OnWidgetSel
         if (!TextUtils.isEmpty(mNfcData)) {
             onNfcTag(mNfcData);
             openNFCPageIfPending();
-        } else if (!TextUtils.isEmpty(mVoiceData)) {
-            sendItemCommand("VoiceCommand", mVoiceData);
-            finish();
         } else {
             selectSitemap(baseUrl, false);
         }
@@ -582,7 +566,7 @@ public class OpenHABMainActivity extends FragmentActivity implements OnWidgetSel
                 return true;
             case R.id.mainmenu_openhab_info:
                 Intent infoIntent = new Intent(this.getApplicationContext(), OpenHABInfoActivity.class);
-                infoIntent.putExtra("openHABBaseUrl", openHABBaseUrl);
+                infoIntent.putExtra(OpenHABVoiceService.OPENHAB_BASE_URL_EXTRA, openHABBaseUrl);
                 infoIntent.putExtra("username", openHABUsername);
                 infoIntent.putExtra("password", openHABPassword);
                 startActivityForResult(infoIntent, INFO_REQUEST_CODE);
@@ -614,29 +598,6 @@ public class OpenHABMainActivity extends FragmentActivity implements OnWidgetSel
                 break;
             case WRITE_NFC_TAG_REQUEST_CODE:
                 Log.d(TAG, "Got back from Write NFC tag");
-                break;
-            case VOICE_RECOGNITION_REQUEST_CODE:
-                Log.d(TAG, "Got back from Voice recognition");
-                setProgressBarIndeterminateVisibility(false);
-                if(resultCode == RESULT_OK) {
-                    ArrayList<String> textMatchList = data
-                            .getStringArrayListExtra(RecognizerIntent.EXTRA_RESULTS);
-                    if (!textMatchList.isEmpty()) {
-                        Log.d(TAG, textMatchList.get(0));
-                        Log.d(TAG, "Recognized text: " + textMatchList.get(0));
-                        Toast.makeText(this, "I recognized: " + textMatchList.get(0),
-                                Toast.LENGTH_LONG).show();
-                        sendItemCommand("VoiceCommand", textMatchList.get(0));
-                    } else {
-                        Log.d(TAG, "Voice recognition returned empty set");
-                        Toast.makeText(this, "I can't read you!",
-                                Toast.LENGTH_LONG).show();
-                    }
-                } else {
-                    Log.d(TAG, "A voice recognition error occured");
-                    Toast.makeText(this, "A voice recognition error occured",
-                            Toast.LENGTH_LONG).show();
-                }
                 break;
             default:
         }
@@ -803,14 +764,18 @@ public class OpenHABMainActivity extends FragmentActivity implements OnWidgetSel
     }
 
     private void launchVoiceRecognition() {
-        Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
-        // Specify the calling package to identify your application
-        intent.putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, ((Object) this).getClass().getPackage().getName());
+        Intent callbackIntent = new Intent(this, OpenHABVoiceService.class);
+        callbackIntent.putExtra(OpenHABVoiceService.OPENHAB_BASE_URL_EXTRA, openHABBaseUrl);
+        PendingIntent openhabPendingIntent = PendingIntent.getService(this, 0, callbackIntent, 0);
+
+        Intent speechIntent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
         // Display an hint to the user about what he should say.
-        intent.putExtra(RecognizerIntent.EXTRA_PROMPT, getString(R.string.info_voice_input));
-        intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
-        intent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1);
-        startActivityForResult(intent, VOICE_RECOGNITION_REQUEST_CODE);
+        speechIntent.putExtra(RecognizerIntent.EXTRA_PROMPT, getString(R.string.info_voice_input));
+        speechIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
+        speechIntent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1);
+        speechIntent.putExtra(RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT, openhabPendingIntent);
+
+        startActivity(speechIntent);
     }
 
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/VoiceWidget.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/VoiceWidget.java
@@ -1,3 +1,12 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
 package org.openhab.habdroid.ui;
 
 import android.app.PendingIntent;
@@ -7,7 +16,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.speech.RecognizerIntent;
 import android.widget.RemoteViews;
+
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.core.OpenHABVoiceService;
 
 /**
  * Implementation of App Widget functionality.
@@ -17,12 +28,10 @@ public class VoiceWidget extends AppWidgetProvider {
     @Override
     public void onUpdate(Context context, AppWidgetManager appWidgetManager, int[] appWidgetIds) {
         // There may be multiple widgets active, so update all of them
-        final int N = appWidgetIds.length;
-        for (int i=0; i<N; i++) {
-            updateAppWidget(context, appWidgetManager, appWidgetIds[i]);
+        for (int appWidgetId : appWidgetIds) {
+            updateAppWidget(context, appWidgetManager, appWidgetId);
         }
     }
-
 
     @Override
     public void onEnabled(Context context) {
@@ -34,33 +43,31 @@ public class VoiceWidget extends AppWidgetProvider {
         // Enter relevant functionality for when the last widget is disabled
     }
 
-    static void updateAppWidget(Context context, AppWidgetManager appWidgetManager,
-            int appWidgetId) {
-
+    private void updateAppWidget(Context context, AppWidgetManager appWidgetManager,
+                                 int appWidgetId) {
         // Construct the RemoteViews object
         RemoteViews views = new RemoteViews(context.getPackageName(), R.layout.voice_widget);
 
-        Intent callbackIntent = new Intent(context, OpenHABMainActivity.class);
-        PendingIntent openhabPendingIntent = PendingIntent.getActivity(context, 9, callbackIntent, 0);
+        Intent callbackIntent = new Intent(context, OpenHABVoiceService.class);
+        PendingIntent openhabPendingIntent = PendingIntent.getService(context, 9, callbackIntent, 0);
 
-        Intent intent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
-        // Specify the calling package to identify your application
-        intent.putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE, VoiceWidget.class.getPackage().getName());
+        Intent speechIntent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
         // Display an hint to the user about what he should say.
-        intent.putExtra(RecognizerIntent.EXTRA_PROMPT, context.getString(R.string.info_voice_input));
-        intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
-        intent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1);
-        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-        intent.putExtra(RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT, openhabPendingIntent);
+        speechIntent.putExtra(RecognizerIntent.EXTRA_PROMPT, context.getString(R.string.info_voice_input));
+        speechIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL, RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
+        speechIntent.putExtra(RecognizerIntent.EXTRA_MAX_RESULTS, 1);
+        speechIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+        speechIntent.putExtra(RecognizerIntent.EXTRA_RESULTS_PENDINGINTENT, openhabPendingIntent);
 
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 6, intent, 0);
+        PendingIntent speechPendingIntent = PendingIntent.getActivity(context, 6, speechIntent, 0);
 
-        views.setOnClickPendingIntent(R.id.btn_mic, pendingIntent);
-        views.setOnClickPendingIntent(R.id.btn_open_main, openhabPendingIntent);
+        views.setOnClickPendingIntent(R.id.btn_mic, speechPendingIntent);
+
+        Intent mainIntent = new Intent(context, OpenHABMainActivity.class);
+        PendingIntent mainPendingIntent = PendingIntent.getActivity(context, 8, mainIntent, 0);
+        views.setOnClickPendingIntent(R.id.btn_open_main, mainPendingIntent);
 
         // Instruct the widget manager to update the widget
         appWidgetManager.updateAppWidget(appWidgetId, views);
     }
 }
-
-

--- a/mobile/src/main/java/org/openhab/habdroid/util/ContinuingIntentService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/ContinuingIntentService.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2010-2014, openHAB.org and others.
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.habdroid.util;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.IBinder;
+import android.os.Looper;
+import android.os.Message;
+
+/**
+ * This class is similar to the {@link android.app.IntentService},
+ * with the main difference that this service does not stop itself automatically
+ * once the intent has been handled.
+ *
+ * This behaviour is necessary for example if the subclass has to wait for asynchronous callbacks.
+ *
+ */
+public abstract class ContinuingIntentService extends Service {
+    private volatile Looper mServiceLooper;
+    private volatile ServiceHandler mServiceHandler;
+    private final String mName;
+    private int mLastStartId = 0;
+
+    private final class ServiceHandler extends Handler {
+        public ServiceHandler(Looper looper) {
+            super(looper);
+        }
+
+        @Override
+        public void handleMessage(Message msg) {
+            onHandleIntent((Intent)msg.obj);
+        }
+    }
+
+    /**
+     * Creates a {@link ContinuingIntentService}.
+     *
+     * @param name Used to name the worker thread, important only for debugging.
+     */
+    public ContinuingIntentService(String name) {
+        super();
+        mName = name;
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        HandlerThread thread = new HandlerThread("IntentService[" + mName + "]");
+        thread.start();
+
+        mServiceLooper = thread.getLooper();
+        mServiceHandler = new ServiceHandler(mServiceLooper);
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        mLastStartId = startId;
+        Message msg = mServiceHandler.obtainMessage();
+        msg.obj = intent;
+        mServiceHandler.sendMessage(msg);
+        return START_NOT_STICKY;
+    }
+
+    /**
+     * @return The start ID of the latest intent received.
+     */
+    protected int getLastStartId(){
+        return mLastStartId;
+    }
+
+    @Override
+    public void onDestroy() {
+        mServiceLooper.quit();
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return null; // binding not supported
+    }
+
+    /**
+     * This method is invoked on the worker thread with a request to process.
+     * Only one Intent is processed at a time, but the processing happens on a
+     * worker thread that runs independently from other application logic.
+     * So, if this code takes a long time, it will hold up other requests to
+     * the same IntentService, but it will not hold up anything else.
+     * When all requests have been handled, the IntentService does not stop itself,
+     * so you need to call {@link #stopSelf} manually.
+     *
+     * @param intent The value passed to {@link
+     *               android.content.Context#startService(android.content.Intent)}.
+     */
+    protected abstract void onHandleIntent(Intent intent);
+}

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -32,6 +32,9 @@
     <string name="settings_openhab_sslhost">Ignoriere SSL Hostnamen</string>
     <string name="settings_openhab_sslhost_summary">Ignoriere Hostname-Prüfung beim SSL-Handshake</string>
     <!-- App messages strings -->
+    <string name="title_voice_widget">OpenHAB Sprachbefehle</string>
+    <string name="info_voice_input">"openHAB, zu Ihren Diensten!"</string>
+    <string name="info_voice_recognized_text">"Erkannter Befehl: %1$s"</string>
     <string name="info_demo_mode">HABDroid läuft im Demo Modus. Unter Einstellungen kann eine eigene openHAB-Instanz konfiguriert werden.</string>
     <string name="info_conn_url">Verbinde mit lokaler URL</string>
     <string name="info_conn_rem_url">Verbinde mit Remote URL</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <!-- App messages strings -->
     <string name="title_voice_widget">OpenHAB Voice Commands</string>
     <string name="info_voice_input">"openHAB, at your command!"</string>
+    <string name="info_voice_recognized_text">"Recognized command: %1$s"</string>
     <string name="info_demo_mode">HABDroid is running in demo mode. To connect to your openHAB please go to settings menu.</string>
     <string name="info_conn_url">Connecting to configured URL</string>
     <string name="info_conn_rem_url">Connecting to remote URL</string>


### PR DESCRIPTION
This pull request fixes the following issues mentioned in #5 :
- HABdroid is not opened anymore when the microphone widget is used
- Text overlay (Toast) is displayed with the recognized command
- Voice recognition works regardless of whether HABdroid is active on the background or not

It does not address the following suggestions (maybe a seperate ticket can be created for these):
- Do not include two on-click functions (execute voice recognition & openHAB) in the widget
- Enable widget for lock screen

A few words about the implementation:
Previously, the voice command functionality was included in the OpenHABMainActivity, which was called by an Intent. That's probably why the HABdroid GUI was always opened, when the voice widget was used. I couldn't find a way to execute voice recognition without the GUI being opened. Extracting the voice command functionality into an service (OpenHABVoiceService.java) solved this problem however.

The OpenHABVoiceService is called from two places: The microphone menu icon inside HABdroid, and the microphone widget.
- In case the service is called from the menu icon, the openHAB URL can be passed in the Intent.
- In case the service is called from the widget, it uses the OpenHABTracker to determine the URL of the openHAB Server. This was a little bit tricky because OpenHABTracker uses asynchronous autodiscovery if the openHAB URL is not configured. (For this reason, the ContinuingIntentService buffers the voice commands until the openHAB URL is discovered.)

I also had to adjust the AsyncServiceResolver a little (besides converting tabs to spaces) because it is called indirectly also from the service. This cast would then not work anymore: ((Activity) mCtx).runOnUiThread(), as the mCtx is not an activity.

I'd be happy to hear about any feedback.