### PR TITLE
Indicate that HABDroid also works on devices without GPS

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -22,6 +22,9 @@
     <uses-permission android:name="org.openhab.habdroid.gcm.permission.C2D_MESSAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-feature
+        android:name="android.hardware.location.gps"
+        android:required="false" />
+    <uses-feature
         android:name="android.hardware.nfc"
         android:required="false" />
     <application


### PR DESCRIPTION
This pull request should fix #33 . I cannot test it because I don't have a device without GPS.
Problem is that HABDroid uses permission ACCESS_FINE_LOCATION. This implies (see http://developer.android.com/guide/topics/manifest/uses-feature-element.html#permissions) that the android.hardware.location.gps feature is required to run HABDroid. As this is not the case, this feature should be marked as required false.

@belovictor: For which feature of HABDroid is ACCESS_FINE_LOCATION necessary? If it is not necessary, it would make more sense to remove this permission request. Let me know then I could update the pull request.