### PR TITLE
Change to use long polling after we successfully have a connection, set ...

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
@@ -330,8 +330,10 @@ public class OpenHABWidgetListFragment extends ListFragment {
         Log.i(TAG, " showPage for " + pageUrl + " longPolling = " + longPolling);
         Log.d(TAG, "isAdded = " + isAdded());
         // Cancel any existing http request to openHAB (typically ongoing long poll)
-        if (!longPolling)
+        if (!longPolling) {
             startProgressIndicator();
+            this.mAtmosphereTrackingId = null;
+        }
         List<BasicHeader> headers = new LinkedList<BasicHeader>();
         if (mActivity.getOpenHABVersion() == 1)
             headers.add(new BasicHeader("Accept", "application/xml"));
@@ -493,10 +495,8 @@ public class OpenHABWidgetListFragment extends ListFragment {
                 getActivity().finish();
             }
         }
-        if (longPolling)
-            showPage(displayPageUrl, false);
-        else
-            showPage(displayPageUrl, true);
+
+        showPage(displayPageUrl, true);
     }
 
     private void stopProgressIndicator() {


### PR DESCRIPTION
...our atmopshere to null to make sure we don't reuse one from a previous session.  This is in regards to #56 .  @belovictor I have been running this all week and have not had any issues, could you try out and let me know.  Someone was kind enough to do the work to bring Atmopshere 2.2.x in OH, so I will be testing against that as well this weekend, hopefully this clears a few of our problems up! 