### PR TITLE
Fixed a build error Android Studio on Windows

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.application'
 
 android {
     compileSdkVersion 21
-    buildToolsVersion '21.0.0'
+    buildToolsVersion '21.1.2'
 
     defaultConfig {
         applicationId "org.openhab.habdroid"


### PR DESCRIPTION
Encountered a problem similar to http://stackoverflow.com/questions/21645961/android-studio-processdebugresources-failed. Fixed by upgrading to the latest version of build tools for 21