### PR TITLE
Make sure #anchor is observed by WebView sitemap elements.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/AnchorWebViewClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/AnchorWebViewClient.java
@@ -1,0 +1,29 @@
+
+package org.openhab.habdroid.ui;
+
+import android.util.Log;
+import android.webkit.WebView;
+import android.webkit.WebViewClient;
+
+class AnchorWebViewClient extends WebViewClient {
+    private static final String TAG = "AnchorWebViewClient";
+    private String anchor = null;
+
+    public AnchorWebViewClient(String url) {
+        int pos = url.lastIndexOf("#") + 1;
+        if(pos != 0 && pos<url.length()) {
+            this.anchor = url.substring(pos);
+            Log.d(TAG, "Found anchor " + anchor + " from url "+ url);
+        } else {
+            Log.d(TAG, "Did not find anchor from url "+ url);
+        }
+    }
+
+    @Override
+    public void onPageFinished(WebView view, String url) {
+        if (anchor != null && !anchor.isEmpty()) {
+            Log.d(TAG, "Now jumping to anchor " + anchor);
+            view.loadUrl("javascript:location.hash = '#" + anchor + "';");
+        }
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -566,7 +566,7 @@ public class OpenHABWidgetAdapter extends ArrayAdapter<OpenHABWidget> {
     			webLayoutParams.height = openHABWidget.getHeight() * 80;
     			webWeb.setLayoutParams(webLayoutParams);
     		}
-    		webWeb.setWebViewClient(new WebViewClient());
+    		webWeb.setWebViewClient(new AnchorWebViewClient(openHABWidget.getUrl()));
             webWeb.getSettings().setJavaScriptEnabled(true);
     		webWeb.loadUrl(openHABWidget.getUrl());
     	break;


### PR DESCRIPTION
Currently when speficying an openHAB WebView sitemap element pointing to
www.url.com/site.html#bottom the anchor (#bottom) is ignored.

Note: This PR might now be necessary. Currently the #anchor (aka
fragment) is not send by openHAB core. This should be fixed by
https://github.com/openhab/openhab/pull/2623
Once that PR is accepted, test whether this PR is required and has
desired effect.

Depends on https://github.com/openhab/openhab/pull/2623