### PR TITLE
Fix issue with huge whitespace in case no icon is displayed in sitemap

### DIFF
--- a/mobile/src/main/res/layout-v21/openhabwidgetlist_frameitem.xml
+++ b/mobile/src/main/res/layout-v21/openhabwidgetlist_frameitem.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:focusable="false"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:minHeight="50dp"
-	>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:focusable="false"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:minHeight="50dp">
+
     <LinearLayout
         android:id="@+id/listdivider"
         android:layout_width="fill_parent"
@@ -17,9 +16,10 @@
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
         android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
         android:layout_marginBottom="7dip"
-        android:gravity="top"
-        />
-    <TextView android:id="@+id/widgetlabel"
+        android:gravity="top" />
+
+    <TextView
+        android:id="@+id/widgetlabel"
         android:gravity="center_vertical"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
@@ -28,6 +28,5 @@
         android:textStyle="bold"
         android:textAllCaps="true"
         android:paddingLeft="5dp"
-        android:textColor="?android:colorPrimary"
-    />
+        android:textColor="?android:colorPrimary" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_chartitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_chartitem.xml
@@ -1,30 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-        android:adjustViewBounds="true"
-        android:paddingLeft="@dimen/widgetlist_item_left_margin"
-        android:paddingRight="@dimen/widgetlist_item_right_margin"
-        android:background="?android:activatedBackgroundIndicator"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:adjustViewBounds="true"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator"
+    >
 
-        >
-<org.openhab.habdroid.util.MySmartImageView
+    <org.openhab.habdroid.util.MySmartImageView
         android:layout_width="fill_parent"
-        android:layout_height="wrap_content" 
+        android:layout_height="wrap_content"
         android:id="@+id/chartimage"
         android:adjustViewBounds="true"
         android:scaleType="fitCenter"
-        android:layout_margin="5dip"
- 		/>
-<LinearLayout 
-    	android:id="@+id/listdivider"
+        android:layout_margin="5dip" />
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
         android:layout_below="@+id/chartimage"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_coloritem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_coloritem.xml
@@ -1,88 +1,87 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:orientation="horizontal"
-  android:descendantFocusability="blocksDescendants"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
-        >
-  <LinearLayout
-	    android:id="@+id/switchleftlayout"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:descendantFocusability="blocksDescendants"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator">
+
+    <LinearLayout
+        android:id="@+id/switchleftlayout"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-		android:layout_alignParentLeft="true"
-      >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:paddingTop="6dip" 
-        android:paddingBottom="6dip" 
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true">
+
+        <org.openhab.habdroid.util.MySmartImageView
+            android:paddingTop="6dip"
+            android:paddingBottom="6dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/widgetimage"
+            android:minHeight="50dip"
+            android:minWidth="50dip"
+            android:maxHeight="50dip"
+            android:maxWidth="50dip" />
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_gravity="center_vertical" />
+    </LinearLayout>
+
+    <LinearLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-        android:id="@+id/widgetimage"
-		android:minHeight="50dip"
-		android:minWidth="50dip"
-		android:maxHeight="50dip"
-		android:maxWidth="50dip"
-		/>
-<TextView android:id="@+id/widgetlabel"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-  			android:layout_gravity="center_vertical"
-    	/>
-</LinearLayout>
-<LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-		android:layout_alignParentRight="true"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
         android:layout_centerInParent="true"
         android:focusable="false"
-        android:focusableInTouchMode="false"
-      >
-<ImageButton
-        android:id="@+id/colorbutton_up"
-        android:paddingLeft="3dip"
-        android:paddingRight="3dip"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_action_up"
-        android:layout_gravity="center_vertical"
-        android:focusable="false"
-        android:focusableInTouchMode="false"
-        />
-<ImageButton
-        android:id="@+id/colorbutton_color"
-        android:paddingLeft="7dip"
-        android:paddingRight="7dip"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/colorwheel" 
-        android:layout_gravity="center_vertical"
-        android:focusable="false"
-        android:focusableInTouchMode="false"
-        />
-<ImageButton
-        android:id="@+id/colorbutton_down"
-        android:paddingLeft="3dip"
-        android:paddingRight="3dip"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_action_down"
-        android:layout_gravity="center_vertical"
-        android:focusable="false"
-        android:focusableInTouchMode="false"
-        />
-</LinearLayout>
-<LinearLayout 
-    	android:id="@+id/listdivider"
+        android:focusableInTouchMode="false">
+
+        <ImageButton
+            android:id="@+id/colorbutton_up"
+            android:paddingLeft="3dip"
+            android:paddingRight="3dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_action_up"
+            android:layout_gravity="center_vertical"
+            android:focusable="false"
+            android:focusableInTouchMode="false" />
+
+        <ImageButton
+            android:id="@+id/colorbutton_color"
+            android:paddingLeft="7dip"
+            android:paddingRight="7dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/colorwheel"
+            android:layout_gravity="center_vertical"
+            android:focusable="false"
+            android:focusableInTouchMode="false" />
+
+        <ImageButton
+            android:id="@+id/colorbutton_down"
+            android:paddingLeft="3dip"
+            android:paddingRight="3dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_action_down"
+            android:layout_gravity="center_vertical"
+            android:focusable="false"
+            android:focusableInTouchMode="false" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
         android:layout_below="@+id/switchleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_coloritem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_coloritem.xml
@@ -2,36 +2,14 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:descendantFocusability="blocksDescendants"
     android:paddingLeft="@dimen/widgetlist_item_left_margin"
     android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:background="?android:activatedBackgroundIndicator">
 
-    <LinearLayout
-        android:id="@+id/switchleftlayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true">
-
-        <org.openhab.habdroid.util.MySmartImageView
-            android:paddingTop="6dip"
-            android:paddingBottom="6dip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/widgetimage"
-            android:minHeight="50dip"
-            android:minWidth="50dip"
-            android:maxHeight="50dip"
-            android:maxWidth="50dip" />
-
-        <TextView
-            android:id="@+id/widgetlabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:layout_gravity="center_vertical" />
-    </LinearLayout>
+    <include
+        android:id="@+id/colorleftlayout"
+        layout="@layout/openhabwidgetlist_icontext" />
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -81,7 +59,7 @@
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
-        android:layout_below="@+id/switchleftlayout"
+        android:layout_below="@+id/colorleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
         android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_fragment.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_fragment.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              android:paddingLeft="@dimen/widgetlist_fragment_left_margin"
-              android:paddingRight="@dimen/widgetlist_fragment_right_margin"
-        >
-    <ListView android:id="@id/android:list"
-              android:layout_width="match_parent"
-              android:layout_height="0dip"
-              android:layout_weight="1"
-              android:drawSelectorOnTop="false"
-              android:footerDividersEnabled="false"
-              android:headerDividersEnabled="false"
-              android:divider="#00000000"
-              android:dividerHeight="0dip"
-              android:scrollbarStyle="outsideOverlay"
-            />
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:paddingLeft="@dimen/widgetlist_fragment_left_margin"
+    android:paddingRight="@dimen/widgetlist_fragment_right_margin">
+
+    <ListView
+        android:id="@id/android:list"
+        android:layout_width="match_parent"
+        android:layout_height="0dip"
+        android:layout_weight="1"
+        android:divider="#00000000"
+        android:dividerHeight="0dip"
+        android:drawSelectorOnTop="false"
+        android:footerDividersEnabled="false"
+        android:headerDividersEnabled="false"
+        android:scrollbarStyle="outsideOverlay" />
 </LinearLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_frameitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_frameitem.xml
@@ -1,32 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:focusable="false"
-    android:paddingLeft="@dimen/widgetlist_item_left_margin"
-    android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:minHeight="50dp"
-    >
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin">
+
     <LinearLayout
         android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="8dip"
-        android:background="?attr/frameWidgetDividerBackground"
-        android:orientation="horizontal"
+        android:layout_marginBottom="7dip"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
         android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-        android:layout_marginBottom="7dip"
+        android:background="?attr/frameWidgetDividerBackground"
         android:gravity="top"
-        />
-    <TextView android:id="@+id/widgetlabel"
-        android:gravity="center_vertical"
+        android:orientation="horizontal" />
+
+    <TextView
+        android:id="@+id/widgetlabel"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
-        android:layout_marginLeft="6dip"
         android:layout_centerVertical="true"
-        android:textStyle="bold"
-        android:textAllCaps="true"
+        android:layout_marginLeft="6dip"
+        android:gravity="center_vertical"
         android:paddingLeft="5dp"
-        />
+        android:textAllCaps="true"
+        android:textStyle="bold" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_genericitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_genericitem.xml
@@ -6,35 +6,15 @@
     android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:background="?android:activatedBackgroundIndicator">
 
-    <org.openhab.habdroid.util.MySmartImageView
-        android:paddingTop="6dip"
-        android:paddingBottom="6dip"
+    <include
+        android:id="@+id/genericleftlayout"
+        layout="@layout/openhabwidgetlist_icontext" />
+
+    <TextView
+        android:id="@+id/widgetvalue"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:id="@+id/widgetimage"
-        android:layout_gravity="center_vertical"
-        android:minHeight="50dip"
-        android:minWidth="50dip"
-        android:maxHeight="50dip"
-        android:maxWidth="50dip" />
-
-    <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_toRightOf="@+id/widgetimage">
-
-        <TextView
-            android:id="@+id/widgetlabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <TextView
-            android:id="@+id/widgetvalue"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceSmall" />
-    </LinearLayout>
+        android:textAppearance="?android:attr/textAppearanceSmall" />
 
     <LinearLayout
         android:id="@+id/listdivider"
@@ -42,7 +22,7 @@
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
-        android:layout_below="@+id/widgetimage"
+        android:layout_below="@+id/genericleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
         android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_genericitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_genericitem.xml
@@ -1,47 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
-        >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:paddingTop="6dip" 
-        android:paddingBottom="6dip" 
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator">
+
+    <org.openhab.habdroid.util.MySmartImageView
+        android:paddingTop="6dip"
+        android:paddingBottom="6dip"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-        android:id="@+id/widgetimage"
-		android:layout_gravity="center_vertical"
-		android:minHeight="50dip"
-		android:minWidth="50dip"
-		android:maxHeight="50dip"
-		android:maxWidth="50dip"
-		/>
-<LinearLayout
-  android:layout_width="wrap_content"
-  android:layout_height="wrap_content"
-  android:layout_toRightOf="@+id/widgetimage">
-  <TextView android:id="@+id/widgetlabel"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-    	/>
-<TextView android:id="@+id/widgetvalue"
-    android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceSmall"
-    />
-</LinearLayout>
-<LinearLayout 
-    	android:id="@+id/listdivider"
+        android:id="@+id/widgetimage"
+        android:layout_gravity="center_vertical"
+        android:minHeight="50dip"
+        android:minWidth="50dip"
+        android:maxHeight="50dip"
+        android:maxWidth="50dip" />
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toRightOf="@+id/widgetimage">
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <TextView
+            android:id="@+id/widgetvalue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
         android:layout_below="@+id/widgetimage"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_groupitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_groupitem.xml
@@ -1,51 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
     android:background="@drawable/list_selector"
-        >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:paddingTop="6dip" 
-        android:paddingBottom="6dip" 
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin">
+
+    <org.openhab.habdroid.util.MySmartImageView
         android:id="@+id/widgetimage"
-		android:layout_gravity="center_vertical"
-		android:minHeight="50dip"
-		android:minWidth="50dip"
-		android:maxHeight="50dip"
-		android:maxWidth="50dip"
-		/>
-<RelativeLayout
-  android:layout_width="wrap_content"
-  android:layout_height="wrap_content"
-  android:orientation="vertical"
-  android:layout_centerVertical="true"
-  android:layout_toRightOf="@+id/widgetimage">
-  <TextView android:id="@+id/widgetlabel"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-    	/>
-<TextView android:id="@+id/widgetvalue"
-    android:layout_width="wrap_content"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:layout_alignParentRight="true"
-        android:layout_marginRight="5dp"
-    />
-</RelativeLayout>
+        android:layout_gravity="center_vertical"
+        android:maxHeight="50dip"
+        android:maxWidth="50dip"
+        android:minHeight="50dip"
+        android:minWidth="50dip"
+        android:paddingBottom="6dip"
+        android:paddingTop="6dip" />
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerVertical="true"
+        android:layout_toRightOf="@+id/widgetimage"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <TextView
+            android:id="@+id/widgetvalue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentRight="true"
+            android:layout_marginRight="5dp"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+    </RelativeLayout>
+
     <LinearLayout
-            android:id="@+id/listdivider"
-            android:layout_width="fill_parent"
-            android:layout_height="1dip"
-            android:background="?attr/widgetlistItemDivider"
-            android:orientation="horizontal"
-            android:layout_below="@+id/widgetimage"
-            android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-            android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-            />
+        android:id="@+id/listdivider"
+        android:layout_width="fill_parent"
+        android:layout_height="1dip"
+        android:layout_below="@+id/widgetimage"
+        android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
+        android:background="?attr/widgetlistItemDivider"
+        android:orientation="horizontal" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_groupitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_groupitem.xml
@@ -6,45 +6,23 @@
     android:paddingLeft="@dimen/widgetlist_item_left_margin"
     android:paddingRight="@dimen/widgetlist_item_right_margin">
 
-    <org.openhab.habdroid.util.MySmartImageView
-        android:id="@+id/widgetimage"
+    <include
+        android:id="@+id/groupleftlayout"
+        layout="@layout/openhabwidgetlist_icontext" />
+
+    <TextView
+        android:id="@+id/widgetvalue"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_vertical"
-        android:maxHeight="50dip"
-        android:maxWidth="50dip"
-        android:minHeight="50dip"
-        android:minWidth="50dip"
-        android:paddingBottom="6dip"
-        android:paddingTop="6dip" />
-
-    <RelativeLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_centerVertical="true"
-        android:layout_toRightOf="@+id/widgetimage"
-        android:orientation="vertical">
-
-        <TextView
-            android:id="@+id/widgetlabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <TextView
-            android:id="@+id/widgetvalue"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_alignParentRight="true"
-            android:layout_marginRight="5dp"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-    </RelativeLayout>
+        android:layout_alignParentRight="true"
+        android:layout_marginRight="5dp"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
 
     <LinearLayout
         android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
-        android:layout_below="@+id/widgetimage"
+        android:layout_below="@+id/groupleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
         android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
         android:background="?attr/widgetlistItemDivider"

--- a/mobile/src/main/res/layout/openhabwidgetlist_icontext.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_icontext.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/icontextlayout"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:layout_alignParentLeft="true">
+
+    <org.openhab.habdroid.util.MySmartImageView
+        android:paddingTop="6dip"
+        android:paddingBottom="6dip"
+        android:layout_width="50dip"
+        android:layout_height="50dip"
+        android:id="@+id/widgetimage"
+        android:layout_gravity="center_vertical"
+        android:maxWidth="50dip"
+        android:minWidth="50dip"
+        android:maxHeight="50dip"
+        android:minHeight="50dip"
+        />
+
+    <TextView
+        android:id="@+id/widgetlabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_vertical"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+</LinearLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_imageitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_imageitem.xml
@@ -1,28 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:background="?android:activatedBackgroundIndicator"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    >
 
-        >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:layout_width="fill_parent"
-        android:layout_height="wrap_content" 
+    <org.openhab.habdroid.util.MySmartImageView
         android:id="@+id/imageimage"
-        android:adjustViewBounds="true"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
         android:layout_margin="5dip"
-		/>
-<LinearLayout 
-    	android:id="@+id/listdivider"
+        android:adjustViewBounds="true" />
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
-        android:background="?android:attr/listDivider"
-        android:orientation="horizontal"
         android:layout_below="@+id/imageimage"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
         android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:background="?android:attr/listDivider"
+        android:orientation="horizontal" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_rollershutteritem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_rollershutteritem.xml
@@ -1,89 +1,88 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:orientation="horizontal"
-  android:descendantFocusability="blocksDescendants"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:descendantFocusability="blocksDescendants"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator"
+    >
 
-        >
-  <LinearLayout
-	    android:id="@+id/rollershutterleftlayout"
+    <LinearLayout
+        android:id="@+id/rollershutterleftlayout"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-		android:layout_alignParentLeft="true"
-      >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:paddingTop="6dip" 
-        android:paddingBottom="6dip" 
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true">
+
+        <org.openhab.habdroid.util.MySmartImageView
+            android:paddingTop="6dip"
+            android:paddingBottom="6dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/widgetimage"
+            android:minHeight="50dip"
+            android:minWidth="50dip"
+            android:maxHeight="50dip"
+            android:maxWidth="50dip" />
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_gravity="center_vertical" />
+    </LinearLayout>
+
+    <LinearLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-        android:id="@+id/widgetimage"
-		android:minHeight="50dip"
-		android:minWidth="50dip"
-		android:maxHeight="50dip"
-		android:maxWidth="50dip"
-		/>
-<TextView android:id="@+id/widgetlabel"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-  			android:layout_gravity="center_vertical"
-    	/>
-</LinearLayout>
-  <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-		android:layout_alignParentRight="true"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
         android:layout_centerInParent="true"
         android:focusable="false"
-        android:focusableInTouchMode="false"
-      >
-<ImageButton
-        android:id="@+id/rollershutterbutton_up"
-        android:paddingLeft="3dip"
-        android:paddingRight="3dip"
-        android:layout_width="40dip"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_action_up"
-        android:layout_gravity="center_vertical"
-        android:focusable="false"
-        android:focusableInTouchMode="false"
-        />
-<ImageButton
-        android:id="@+id/rollershutterbutton_stop"
-        android:paddingLeft="7dip"
-        android:paddingRight="7dip"
-        android:layout_width="46dip"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_action_cancel" 
-        android:layout_gravity="center_vertical"
-        android:focusable="false"
-        android:focusableInTouchMode="false"
-        />
-<ImageButton
-        android:id="@+id/rollershutterbutton_down"
-        android:paddingLeft="3dip"
-        android:paddingRight="3dip"
-        android:layout_width="40dip"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_action_down"
-        android:layout_gravity="center_vertical"
-        android:focusable="false"
-        android:focusableInTouchMode="false"
-        />
-</LinearLayout>
-<LinearLayout 
-    	android:id="@+id/listdivider"
+        android:focusableInTouchMode="false">
+
+        <ImageButton
+            android:id="@+id/rollershutterbutton_up"
+            android:paddingLeft="3dip"
+            android:paddingRight="3dip"
+            android:layout_width="40dip"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_action_up"
+            android:layout_gravity="center_vertical"
+            android:focusable="false"
+            android:focusableInTouchMode="false" />
+
+        <ImageButton
+            android:id="@+id/rollershutterbutton_stop"
+            android:paddingLeft="7dip"
+            android:paddingRight="7dip"
+            android:layout_width="46dip"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_action_cancel"
+            android:layout_gravity="center_vertical"
+            android:focusable="false"
+            android:focusableInTouchMode="false" />
+
+        <ImageButton
+            android:id="@+id/rollershutterbutton_down"
+            android:paddingLeft="3dip"
+            android:paddingRight="3dip"
+            android:layout_width="40dip"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_action_down"
+            android:layout_gravity="center_vertical"
+            android:focusable="false"
+            android:focusableInTouchMode="false" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
         android:layout_below="@+id/rollershutterleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_rollershutteritem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_rollershutteritem.xml
@@ -2,37 +2,15 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:descendantFocusability="blocksDescendants"
     android:paddingLeft="@dimen/widgetlist_item_left_margin"
     android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:background="?android:activatedBackgroundIndicator"
     >
 
-    <LinearLayout
+    <include
         android:id="@+id/rollershutterleftlayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true">
-
-        <org.openhab.habdroid.util.MySmartImageView
-            android:paddingTop="6dip"
-            android:paddingBottom="6dip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/widgetimage"
-            android:minHeight="50dip"
-            android:minWidth="50dip"
-            android:maxHeight="50dip"
-            android:maxWidth="50dip" />
-
-        <TextView
-            android:id="@+id/widgetlabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:layout_gravity="center_vertical" />
-    </LinearLayout>
+        layout="@layout/openhabwidgetlist_icontext" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/mobile/src/main/res/layout/openhabwidgetlist_sectionswitchitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_sectionswitchitem.xml
@@ -2,36 +2,14 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:paddingLeft="@dimen/widgetlist_item_left_margin"
     android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:background="?android:activatedBackgroundIndicator"
     >
 
-    <LinearLayout
+    <include
         android:id="@+id/sectionleftlayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true">
-
-        <org.openhab.habdroid.util.MySmartImageView
-            android:paddingTop="6dip"
-            android:paddingBottom="6dip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/widgetimage"
-            android:minHeight="50dip"
-            android:minWidth="50dip"
-            android:maxHeight="50dip"
-            android:maxWidth="50dip" />
-
-        <TextView
-            android:id="@+id/widgetlabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:layout_gravity="center_vertical" />
-    </LinearLayout>
+        layout="@layout/openhabwidgetlist_icontext" />
 
     <TextView
         android:id="@+id/widgetvalue"

--- a/mobile/src/main/res/layout/openhabwidgetlist_sectionswitchitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_sectionswitchitem.xml
@@ -1,66 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:orientation="horizontal"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator"
+    >
 
-        >
-  <LinearLayout
-	    android:id="@+id/sectionleftlayout"
+    <LinearLayout
+        android:id="@+id/sectionleftlayout"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-		android:layout_alignParentLeft="true"
-      >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:paddingTop="6dip" 
-        android:paddingBottom="6dip" 
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true">
+
+        <org.openhab.habdroid.util.MySmartImageView
+            android:paddingTop="6dip"
+            android:paddingBottom="6dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/widgetimage"
+            android:minHeight="50dip"
+            android:minWidth="50dip"
+            android:maxHeight="50dip"
+            android:maxWidth="50dip" />
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_gravity="center_vertical" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/widgetvalue"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-        android:id="@+id/widgetimage"
-		android:minHeight="50dip"
-		android:minWidth="50dip"
-		android:maxHeight="50dip"
-		android:maxWidth="50dip"
-		/>
-<TextView android:id="@+id/widgetlabel"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-  			android:layout_gravity="center_vertical"
-    	/>
-</LinearLayout>
-<TextView android:id="@+id/widgetvalue"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-    		android:layout_toLeftOf="@+id/sectionswitchradiogroup"
-        	android:layout_centerVertical="true"
-    	/>
-  <RadioGroup
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:layout_toLeftOf="@+id/sectionswitchradiogroup"
+        android:layout_centerVertical="true" />
+
+    <RadioGroup
         android:id="@+id/sectionswitchradiogroup"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="horizontal" 
+        android:orientation="horizontal"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
         android:layout_margin="0px"
-            style="@style/buttonStyle2"
-        >
+        style="@style/buttonStyle2">
         android:focusable="false"
-        android:focusableInTouchMode="false"
-  </RadioGroup>
-<LinearLayout 
-    	android:id="@+id/listdivider"
+        android:focusableInTouchMode="false"</RadioGroup>
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
         android:layout_below="@+id/sectionleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_sectionswitchitem_button.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_sectionswitchitem_button.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<org.openhab.habdroid.ui.widget.SegmentedControlButton
-    xmlns:android="http://schemas.android.com/apk/res/android"
-            style="@style/buttonStyle2"
-            android:text=""
-        android:focusable="false"
-        android:focusableInTouchMode="false"
-            />
+<org.openhab.habdroid.ui.widget.SegmentedControlButton xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/buttonStyle2"
+    android:text=""
+    android:focusable="false"
+    android:focusableInTouchMode="false" />

--- a/mobile/src/main/res/layout/openhabwidgetlist_selectionitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_selectionitem.xml
@@ -1,56 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:orientation="horizontal"
-  android:descendantFocusability="blocksDescendants"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:descendantFocusability="blocksDescendants"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator"
+    >
 
-        >
-  <LinearLayout
-	    android:id="@+id/selectionleftlayout"
+    <LinearLayout
+        android:id="@+id/selectionleftlayout"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-		android:layout_alignParentLeft="true"
-      >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:paddingTop="6dip" 
-        android:paddingBottom="6dip" 
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-        android:id="@+id/widgetimage"
-		android:minHeight="50dip"
-		android:minWidth="50dip"
-		android:maxHeight="50dip"
-		android:maxWidth="50dip"
-		/>
-<TextView android:id="@+id/widgetlabel"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-  			android:layout_gravity="center_vertical"
-    	/>
-</LinearLayout>
-<Spinner 
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true">
+
+        <org.openhab.habdroid.util.MySmartImageView
+            android:paddingTop="6dip"
+            android:paddingBottom="6dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/widgetimage"
+            android:minHeight="50dip"
+            android:minWidth="50dip"
+            android:maxHeight="50dip"
+            android:maxWidth="50dip" />
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_gravity="center_vertical" />
+    </LinearLayout>
+
+    <Spinner
         android:id="@+id/selectionspinner"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
         android:focusable="false"
-        android:focusableInTouchMode="false"
-	/>
-<LinearLayout 
-    	android:id="@+id/listdivider"
+        android:focusableInTouchMode="false" />
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
         android:layout_below="@+id/selectionleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_selectionitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_selectionitem.xml
@@ -2,37 +2,15 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:descendantFocusability="blocksDescendants"
     android:paddingLeft="@dimen/widgetlist_item_left_margin"
     android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:background="?android:activatedBackgroundIndicator"
     >
 
-    <LinearLayout
+    <include
         android:id="@+id/selectionleftlayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true">
-
-        <org.openhab.habdroid.util.MySmartImageView
-            android:paddingTop="6dip"
-            android:paddingBottom="6dip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/widgetimage"
-            android:minHeight="50dip"
-            android:minWidth="50dip"
-            android:maxHeight="50dip"
-            android:maxWidth="50dip" />
-
-        <TextView
-            android:id="@+id/widgetlabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:layout_gravity="center_vertical" />
-    </LinearLayout>
+        layout="@layout/openhabwidgetlist_icontext" />
 
     <Spinner
         android:id="@+id/selectionspinner"

--- a/mobile/src/main/res/layout/openhabwidgetlist_setpointitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_setpointitem.xml
@@ -2,36 +2,14 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:paddingLeft="@dimen/widgetlist_item_left_margin"
     android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:background="?android:activatedBackgroundIndicator"
     >
 
-    <LinearLayout
-        android:layout_width="wrap_content"
+    <include
         android:id="@+id/setpointleftlayout"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true">
-
-        <org.openhab.habdroid.util.MySmartImageView
-            android:paddingTop="6dip"
-            android:paddingBottom="6dip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/widgetimage"
-            android:minHeight="50dip"
-            android:minWidth="50dip"
-            android:maxHeight="50dip"
-            android:maxWidth="50dip" />
-
-        <TextView
-            android:id="@+id/widgetlabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:layout_gravity="center_vertical" />
-    </LinearLayout>
+        layout="@layout/openhabwidgetlist_icontext" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/mobile/src/main/res/layout/openhabwidgetlist_setpointitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_setpointitem.xml
@@ -1,61 +1,64 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:orientation="horizontal"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator"
+    >
 
-        >
-  <LinearLayout
+    <LinearLayout
         android:layout_width="wrap_content"
         android:id="@+id/setpointleftlayout"
-        android:layout_height="wrap_content" 
-		android:layout_alignParentLeft="true"
-      >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:paddingTop="6dip" 
-        android:paddingBottom="6dip" 
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-        android:id="@+id/widgetimage"
-		android:minHeight="50dip"
-		android:minWidth="50dip"
-		android:maxHeight="50dip"
-		android:maxWidth="50dip"
-		/>
-<TextView android:id="@+id/widgetlabel"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-  			android:layout_gravity="center_vertical"
-    	/>
-</LinearLayout>
-  <LinearLayout
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-		android:layout_alignParentRight="true"
-      >
-<Button
-        android:id="@+id/setpointbutton_minus"
-        android:layout_width="40dip"
         android:layout_height="wrap_content"
-        android:text="-" />
-  <TextView android:id="@+id/widgetvalue"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-    	/>
-<Button
-        android:id="@+id/setpointbutton_plus"
-        android:layout_width="40dip"
+        android:layout_alignParentLeft="true">
+
+        <org.openhab.habdroid.util.MySmartImageView
+            android:paddingTop="6dip"
+            android:paddingBottom="6dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/widgetimage"
+            android:minHeight="50dip"
+            android:minWidth="50dip"
+            android:maxHeight="50dip"
+            android:maxWidth="50dip" />
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_gravity="center_vertical" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="+" />
-</LinearLayout>
-<LinearLayout 
-    	android:id="@+id/listdivider"
+        android:layout_alignParentRight="true">
+
+        <Button
+            android:id="@+id/setpointbutton_minus"
+            android:layout_width="40dip"
+            android:layout_height="wrap_content"
+            android:text="-" />
+
+        <TextView
+            android:id="@+id/widgetvalue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <Button
+            android:id="@+id/setpointbutton_plus"
+            android:layout_width="40dip"
+            android:layout_height="wrap_content"
+            android:text="+" />
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
@@ -63,6 +66,5 @@
         android:layout_below="@+id/setpointleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
         android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-        android:layout_alignParentLeft="true"
-       />
+        android:layout_alignParentLeft="true" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_slideritem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_slideritem.xml
@@ -2,36 +2,14 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:paddingLeft="@dimen/widgetlist_item_left_margin"
     android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:background="?android:activatedBackgroundIndicator"
     >
 
-    <LinearLayout
+    <include
         android:id="@+id/sliderleftlayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true">
-
-        <org.openhab.habdroid.util.MySmartImageView
-            android:paddingTop="6dip"
-            android:paddingBottom="6dip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/widgetimage"
-            android:minHeight="50dip"
-            android:minWidth="50dip"
-            android:maxHeight="50dip"
-            android:maxWidth="50dip" />
-
-        <TextView
-            android:id="@+id/widgetlabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:layout_gravity="center_vertical" />
-    </LinearLayout>
+        layout="@layout/openhabwidgetlist_icontext" />
 
     <SeekBar
         android:id="@+id/sliderseekbar"
@@ -39,7 +17,7 @@
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
-        android:max="100"></SeekBar>
+        android:max="100" />
 
     <LinearLayout
         android:id="@+id/listdivider"

--- a/mobile/src/main/res/layout/openhabwidgetlist_slideritem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_slideritem.xml
@@ -1,53 +1,53 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:orientation="horizontal"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator"
+    >
 
-        >
-  <LinearLayout
-	    android:id="@+id/sliderleftlayout"
+    <LinearLayout
+        android:id="@+id/sliderleftlayout"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-		android:layout_alignParentLeft="true"
-      >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:paddingTop="6dip" 
-        android:paddingBottom="6dip" 
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-        android:id="@+id/widgetimage"
-		android:minHeight="50dip"
-		android:minWidth="50dip"
-		android:maxHeight="50dip"
-		android:maxWidth="50dip"
-		/>
-<TextView android:id="@+id/widgetlabel"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-  			android:layout_gravity="center_vertical"
-    	/>
-</LinearLayout>
-<SeekBar android:id="@+id/sliderseekbar"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true">
+
+        <org.openhab.habdroid.util.MySmartImageView
+            android:paddingTop="6dip"
+            android:paddingBottom="6dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/widgetimage"
+            android:minHeight="50dip"
+            android:minWidth="50dip"
+            android:maxHeight="50dip"
+            android:maxWidth="50dip" />
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_gravity="center_vertical" />
+    </LinearLayout>
+
+    <SeekBar
+        android:id="@+id/sliderseekbar"
         android:layout_width="130dip"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
-        android:max="100">
-</SeekBar>
-<LinearLayout 
-    	android:id="@+id/listdivider"
+        android:max="100"></SeekBar>
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
         android:layout_below="@+id/sliderleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_switchitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_switchitem.xml
@@ -2,36 +2,14 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:paddingLeft="@dimen/widgetlist_item_left_margin"
-    android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:background="?android:activatedBackgroundIndicator"
-    >
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin">
 
-    <LinearLayout
+
+    <include
         android:id="@+id/switchleftlayout"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true">
-
-        <org.openhab.habdroid.util.MySmartImageView
-            android:paddingTop="6dip"
-            android:paddingBottom="6dip"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/widgetimage"
-            android:minHeight="50dip"
-            android:minWidth="50dip"
-            android:maxHeight="50dip"
-            android:maxWidth="50dip" />
-
-        <TextView
-            android:id="@+id/widgetlabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:layout_gravity="center_vertical" />
-    </LinearLayout>
+        layout="@layout/openhabwidgetlist_icontext" />
 
     <android.support.v7.widget.SwitchCompat
         android:id="@+id/switchswitch"
@@ -39,17 +17,17 @@
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
+        android:layout_marginRight="3dip"
         android:focusable="false"
-        android:focusableInTouchMode="false"
-        android:layout_marginRight="3dip" />
+        android:focusableInTouchMode="false" />
 
     <LinearLayout
         android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
-        android:background="?android:attr/listDivider"
-        android:orientation="horizontal"
         android:layout_below="@+id/switchleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
+        android:background="?android:attr/listDivider"
+        android:orientation="horizontal" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_switchitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_switchitem.xml
@@ -1,55 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:orientation="horizontal"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator"
+    >
 
-        >
-  <LinearLayout
-	    android:id="@+id/switchleftlayout"
+    <LinearLayout
+        android:id="@+id/switchleftlayout"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-		android:layout_alignParentLeft="true"
-      >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:paddingTop="6dip" 
-        android:paddingBottom="6dip" 
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-        android:id="@+id/widgetimage"
-		android:minHeight="50dip"
-		android:minWidth="50dip"
-		android:maxHeight="50dip"
-		android:maxWidth="50dip"
-		/>
-<TextView android:id="@+id/widgetlabel"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-  			android:layout_gravity="center_vertical"
-    	/>
-</LinearLayout>
-<android.support.v7.widget.SwitchCompat android:id="@+id/switchswitch"
+        android:layout_height="wrap_content"
+        android:layout_alignParentLeft="true">
+
+        <org.openhab.habdroid.util.MySmartImageView
+            android:paddingTop="6dip"
+            android:paddingBottom="6dip"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/widgetimage"
+            android:minHeight="50dip"
+            android:minWidth="50dip"
+            android:maxHeight="50dip"
+            android:maxWidth="50dip" />
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_gravity="center_vertical" />
+    </LinearLayout>
+
+    <android.support.v7.widget.SwitchCompat
+        android:id="@+id/switchswitch"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
         android:focusable="false"
         android:focusableInTouchMode="false"
-        android:layout_marginRight="3dip"
-    />
-<LinearLayout 
-    	android:id="@+id/listdivider"
+        android:layout_marginRight="3dip" />
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
         android:layout_below="@+id/switchleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_textitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_textitem.xml
@@ -6,39 +6,18 @@
     android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:background="@drawable/list_selector">
 
-    <org.openhab.habdroid.util.MySmartImageView
-        android:paddingTop="6dip"
-        android:paddingBottom="6dip"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/widgetimage"
-        android:layout_gravity="center_vertical"
-        android:minHeight="50dip"
-        android:minWidth="50dip"
-        android:maxHeight="50dip"
-        android:maxWidth="50dip" />
+    <include
+        android:id="@+id/textleftlayout"
+        layout="@layout/openhabwidgetlist_icontext" />
 
-    <RelativeLayout
+    <TextView
+        android:id="@+id/widgetvalue"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
         android:layout_centerVertical="true"
-        android:layout_toRightOf="@+id/widgetimage">
-
-        <TextView
-            android:id="@+id/widgetlabel"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <TextView
-            android:id="@+id/widgetvalue"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:layout_alignParentRight="true"
-            android:layout_marginRight="5dp" />
-    </RelativeLayout>
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:layout_alignParentRight="true"
+        android:layout_marginRight="5dp" />
 
     <LinearLayout
         android:id="@+id/listdivider"
@@ -46,7 +25,7 @@
         android:layout_height="1dip"
         android:background="?attr/widgetlistItemDivider"
         android:orientation="horizontal"
-        android:layout_below="@+id/widgetimage"
+        android:layout_below="@+id/textleftlayout"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
         android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_textitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_textitem.xml
@@ -1,51 +1,52 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="@drawable/list_selector"
-        >
-<org.openhab.habdroid.util.MySmartImageView 
-        android:paddingTop="6dip" 
-        android:paddingBottom="6dip" 
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="@drawable/list_selector">
+
+    <org.openhab.habdroid.util.MySmartImageView
+        android:paddingTop="6dip"
+        android:paddingBottom="6dip"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content" 
-        android:id="@+id/widgetimage"
-		android:layout_gravity="center_vertical"
-		android:minHeight="50dip"
-		android:minWidth="50dip"
-		android:maxHeight="50dip"
-		android:maxWidth="50dip"
-		/>
-<RelativeLayout
-  android:layout_width="wrap_content"
-  android:layout_height="wrap_content"
-  android:orientation="vertical"
-  android:layout_centerVertical="true"
-  android:layout_toRightOf="@+id/widgetimage">
-  <TextView android:id="@+id/widgetlabel"
-        	android:layout_width="wrap_content"
-        	android:layout_height="wrap_content"
-        	android:textAppearance="?android:attr/textAppearanceMedium"
-    	/>
-<TextView android:id="@+id/widgetvalue"
-    android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textAppearance="?android:attr/textAppearanceMedium"
-        android:layout_alignParentRight="true"
-        android:layout_marginRight="5dp"
-    />
-</RelativeLayout>
+        android:id="@+id/widgetimage"
+        android:layout_gravity="center_vertical"
+        android:minHeight="50dip"
+        android:minWidth="50dip"
+        android:maxHeight="50dip"
+        android:maxWidth="50dip" />
+
+    <RelativeLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_centerVertical="true"
+        android:layout_toRightOf="@+id/widgetimage">
+
+        <TextView
+            android:id="@+id/widgetlabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <TextView
+            android:id="@+id/widgetvalue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:layout_alignParentRight="true"
+            android:layout_marginRight="5dp" />
+    </RelativeLayout>
+
     <LinearLayout
-            android:id="@+id/listdivider"
-            android:layout_width="fill_parent"
-            android:layout_height="1dip"
-            android:background="?attr/widgetlistItemDivider"
-            android:orientation="horizontal"
-            android:layout_below="@+id/widgetimage"
-            android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-            android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-           />
+        android:id="@+id/listdivider"
+        android:layout_width="fill_parent"
+        android:layout_height="1dip"
+        android:background="?attr/widgetlistItemDivider"
+        android:orientation="horizontal"
+        android:layout_below="@+id/widgetimage"
+        android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_videoitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_videoitem.xml
@@ -1,30 +1,28 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="wrap_content"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator"
+    >
 
-        >
-  <VideoView 
-      android:id="@+id/videovideo"
-      android:layout_width="fill_parent"
-      android:layout_height="200dip"
-      android:layout_margin="5dip"
-      android:layout_centerHorizontal="true"
-      android:adjustViewBounds="true"
-      android:minHeight="200dip"
-      />
-  <LinearLayout 
-      android:id="@+id/listdivider"
+    <VideoView
+        android:id="@+id/videovideo"
+        android:layout_width="fill_parent"
+        android:layout_height="200dip"
+        android:layout_margin="5dip"
+        android:layout_centerHorizontal="true"
+        android:adjustViewBounds="true"
+        android:minHeight="200dip" />
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
         android:layout_below="@+id/videovideo"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_videomjpegitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_videomjpegitem.xml
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:paddingLeft="@dimen/widgetlist_item_left_margin"
     android:paddingRight="@dimen/widgetlist_item_right_margin"
     android:background="?android:activatedBackgroundIndicator"
-
     >
+
     <ImageView
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:id="@+id/mjpegimage"
         android:adjustViewBounds="true"
-        android:layout_margin="5dip"
-        />
+        android:layout_margin="5dip" />
+
     <LinearLayout
         android:id="@+id/listdivider"
         android:layout_width="fill_parent"
@@ -23,6 +22,5 @@
         android:orientation="horizontal"
         android:layout_below="@+id/imageimage"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-        />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>

--- a/mobile/src/main/res/layout/openhabwidgetlist_webitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_webitem.xml
@@ -1,29 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-  xmlns:android="http://schemas.android.com/apk/res/android"
-  android:layout_width="fill_parent"
-  android:layout_height="match_parent"
-  android:adjustViewBounds="true"
-  android:paddingLeft="@dimen/widgetlist_item_left_margin"
-  android:paddingRight="@dimen/widgetlist_item_right_margin"
-  android:background="?android:activatedBackgroundIndicator"
-
-        >
-<WebView 
-    android:id="@+id/webweb"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="match_parent"
     android:adjustViewBounds="true"
-    android:layout_margin="5dip"
-    />
-<LinearLayout 
-    	android:id="@+id/listdivider"
+    android:paddingLeft="@dimen/widgetlist_item_left_margin"
+    android:paddingRight="@dimen/widgetlist_item_right_margin"
+    android:background="?android:activatedBackgroundIndicator"
+    >
+
+    <WebView
+        android:id="@+id/webweb"
+        android:layout_width="fill_parent"
+        android:layout_height="match_parent"
+        android:adjustViewBounds="true"
+        android:layout_margin="5dip" />
+
+    <LinearLayout
+        android:id="@+id/listdivider"
         android:layout_width="fill_parent"
         android:layout_height="1dip"
         android:background="?android:attr/listDivider"
         android:orientation="horizontal"
         android:layout_below="@+id/webweb"
         android:layout_marginLeft="@dimen/widgetlist_divider_left_margin"
-        android:layout_marginRight="@dimen/widgetlist_divider_right_margin"
-       />
+        android:layout_marginRight="@dimen/widgetlist_divider_right_margin" />
 </RelativeLayout>


### PR DESCRIPTION
Fixes #130.
This fixes the issue that huge whitespace is displayed in case no icon is available for an item in the sitemap.
The main solution was to define a fixed layout_width/layout_height for the MySmartImageView. Besides that, I have formatted the xml files and extracted the icon and text into a seperate xml which is not included by the other layout xmls.
This pull requests contains two commits, one with the actual changes and another one with only formatting adjustments (for easier review).