### PR TITLE
Enable display of proper rollershutter control for rollershutter groups.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABItem.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABItem.java
@@ -30,6 +30,7 @@ import org.w3c.dom.NodeList;
 public class OpenHABItem {
 	private String name;
 	private String type;
+	private String groupType;
 	private String state = "";
 	private String link;
 	private final static String TAG = "OpenHABItem";
@@ -41,6 +42,8 @@ public class OpenHABItem {
 				Node childNode = childNodes.item(i);
 				if (childNode.getNodeName().equals("type")) {
 					this.setType(childNode.getTextContent());
+				} else if (childNode.getNodeName().equals("groupType")) {
+					this.setGroupType(childNode.getTextContent());
 				} else if (childNode.getNodeName().equals("name")) {
 					this.setName(childNode.getTextContent());
 				} else if (childNode.getNodeName().equals("state")) {
@@ -60,6 +63,8 @@ public class OpenHABItem {
             try {
                 if (jsonObject.has("type"))
                     this.setType(jsonObject.getString("type"));
+				if (jsonObject.has("groupType"))
+					this.setGroupType(jsonObject.getString("groupType"));
                 if (jsonObject.has("name"))
                     this.setName(jsonObject.getString("name"));
                 if (jsonObject.has("state")) {
@@ -90,6 +95,14 @@ public class OpenHABItem {
 
 	public void setType(String type) {
 		this.type = type;
+	}
+
+	public String getGroupType() {
+		return groupType;
+	}
+
+	public void setGroupType(String groupType) {
+		this.groupType = groupType;
 	}
 
 	public String getState() {

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABNFCActionList.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABNFCActionList.java
@@ -39,7 +39,8 @@ public class OpenHABNFCActionList {
 					actionCommands.add("OFF");
 					actionNames.add("Toggle");
 					actionCommands.add("TOGGLE");
-				} else if (openHABWidget.getItem().getType().equals("RollershutterItem")) {
+				} else if ("RollershutterItem".equals(openHABWidget.getItem().getType()) ||
+						("Rollershutter".equals(openHABWidget.getItem().getGroupType()))) {
 					actionNames.add("Up");
 					actionCommands.add("UP");
 					actionNames.add("Down");

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -710,7 +710,8 @@ public class OpenHABWidgetAdapter extends ArrayAdapter<OpenHABWidget> {
     			return TYPE_SECTIONSWITCH;
     		} else if (openHABWidget.getItem() != null) {
     			if (openHABWidget.getItem().getType()!= null) {
-	    			if (openHABWidget.getItem().getType().equals("RollershutterItem"))
+	    			if ("RollershutterItem".equals(openHABWidget.getItem().getType()) ||
+							"Rollershutter".equals(openHABWidget.getItem().getGroupType()))
 	    				return TYPE_ROLLERSHUTTER;
 	    			else
 	    				return TYPE_SWITCH;
@@ -749,7 +750,7 @@ public class OpenHABWidgetAdapter extends ArrayAdapter<OpenHABWidget> {
     		return TYPE_GENERICITEM;
     	}
     }
-	
+
     public void setOpenHABBaseUrl(String baseUrl) {
     	openHABBaseUrl = baseUrl;
     }


### PR DESCRIPTION
Thanks to https://github.com/eclipse/smarthome/pull/1253 development we now can distinguish between switch and rollershutter item and display proper control widget for the group.

Bug: https://github.com/openhab/openhab.android/issues/141
Signed-off-by: Robert Michalak <rbrt.michalak@gmail.com>