### PR TITLE
Clearing recycled chart image

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -486,6 +486,8 @@ public class OpenHABWidgetAdapter extends ArrayAdapter<OpenHABWidget> {
    		break;
     	case TYPE_CHART:
     		MySmartImageView chartImage = (MySmartImageView)widgetView.findViewById(R.id.chartimage);
+    		//Always clear the drawable so no images from recycled views appear
+    		chartImage.setImageDrawable(null);
     		OpenHABItem chartItem = openHABWidget.getItem();
     		Random random = new Random();
     		String chartUrl = "";


### PR DESCRIPTION
I found an issue when loading chart images. If it takes some time for
the image to load the image from a recycled image view is displayed.
After some time the correct image loads, but it’s confusing because it
looks like the image has already been loaded. I fixed the problem by
setting the image drawable to null before loading the image url.

I also added multidex support because I couldn’t build the app without
it and Android Studio removed two unused imports.

I’ve already tested this and is seams to work very good. Please merge
this to your app.

Signed-off-by: David Masshardt <david@masshardt.ch> (github:
TheNetStriker)