### PR TITLE
Fetch icons from correct path for OH2

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -23,6 +23,9 @@ android {
             buildConfigField 'boolean', IS_DEVELOPER, 'true'
         }
     }
+    testOptions {
+        unitTests.returnDefaultValues = true
+    }
 }
 
 repositories {
@@ -52,5 +55,5 @@ dependencies {
 
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'junit:junit:4.12'
-
+    testCompile 'org.json:json:20140107'
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB1Sitemap.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB1Sitemap.java
@@ -1,0 +1,61 @@
+package org.openhab.habdroid.model;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+public class OpenHAB1Sitemap extends OpenHABSitemap {
+    public OpenHAB1Sitemap(Node startNode) {
+        if (startNode.hasChildNodes()) {
+            NodeList childNodes = startNode.getChildNodes();
+            for (int i = 0; i < childNodes.getLength(); i ++) {
+                Node childNode = childNodes.item(i);
+                if (childNode.getNodeName().equals("name")) {
+                    this.setName(childNode.getTextContent());
+                } else if (childNode.getNodeName().equals("label")) {
+                    this.setLabel(childNode.getTextContent());
+                } else if (childNode.getNodeName().equals("link")) {
+                    this.setLink(childNode.getTextContent());
+                } else if (childNode.getNodeName().equals("icon")) {
+                    this.setIcon(childNode.getTextContent());
+                } else if (childNode.getNodeName().equals("homepage")) {
+                    if (childNode.hasChildNodes()) {
+                        NodeList homepageNodes = childNode.getChildNodes();
+                        for (int j = 0; j < homepageNodes.getLength(); j++) {
+                            Node homepageChildNode = homepageNodes.item(j);
+                            if (homepageChildNode.getNodeName().equals("link")) {
+                                this.setHomepageLink(homepageChildNode.getTextContent());
+                            } else if (homepageChildNode.getNodeName().equals("leaf")) {
+                                if (homepageChildNode.getTextContent().equals("true")) {
+                                    setLeaf(true);
+                                } else {
+                                    setLeaf(false);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    public static final Parcelable.Creator<OpenHABSitemap> CREATOR = new Parcelable.Creator<OpenHABSitemap>() {
+        public OpenHABSitemap createFromParcel(Parcel in) {
+            return new OpenHAB1Sitemap(in);
+        }
+
+        public OpenHABSitemap[] newArray(int size) {
+            return new OpenHAB1Sitemap[size];
+        }
+    };
+
+    public OpenHAB1Sitemap(Parcel in) {
+        super(in);
+    }
+
+    @Override
+    public String getIconPath() {
+        return String.format("images/%s.png", getIcon());
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB1Widget.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB1Widget.java
@@ -1,0 +1,89 @@
+package org.openhab.habdroid.model;
+
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+import java.util.ArrayList;
+
+public class OpenHAB1Widget extends OpenHABWidget {
+    public OpenHAB1Widget() {
+    }
+
+    @Override
+    public String getIconPath() {
+        return String.format("images/%s.png", getIcon());
+    }
+
+    private OpenHAB1Widget(OpenHABWidget parent, Node startNode) {
+        this.parent = parent;
+        this.children = new ArrayList<OpenHABWidget>();
+        this.mappings = new ArrayList<OpenHABWidgetMapping>();
+        if (startNode.hasChildNodes()) {
+            NodeList childNodes = startNode.getChildNodes();
+            for (int i = 0; i < childNodes.getLength(); i ++) {
+                Node childNode = childNodes.item(i);
+                String childNodeName = childNode.getNodeName();
+                String childNodeTextContent = childNode.getTextContent();
+                if (childNodeName.equals("item")) {
+                    this.setItem(new OpenHABItem(childNode));
+                } else if (childNodeName.equals("linkedPage")) {
+                    this.setLinkedPage(new OpenHABLinkedPage(childNode));
+                } else if (childNodeName.equals("widget")) {
+                    createOpenHABWidgetFromNode(this, childNode);
+                } else {
+                    if (childNodeName.equals("type")) {
+                        this.setType(childNodeTextContent);
+                    } else if (childNodeName.equals("widgetId")) {
+                        this.setId(childNodeTextContent);
+                    } else if (childNodeName.equals("label")) {
+                        this.setLabel(childNodeTextContent);
+                    } else if (childNodeName.equals("icon")) {
+                        this.setIcon(childNodeTextContent);
+                    } else if (childNodeName.equals("url")) {
+                        this.setUrl(childNodeTextContent);
+                    } else if (childNodeName.equals("minValue")) {
+                        setMinValue(Float.valueOf(childNodeTextContent).floatValue());
+                    } else if (childNodeName.equals("maxValue")) {
+                        setMaxValue(Float.valueOf(childNodeTextContent).floatValue());
+                    } else if (childNodeName.equals("step")) {
+                        setStep(Float.valueOf(childNodeTextContent).floatValue());
+                    } else if (childNodeName.equals("refresh")) {
+                        setRefresh(Integer.valueOf(childNodeTextContent).intValue());
+                    } else if (childNodeName.equals("period")) {
+                        setPeriod(childNodeTextContent);
+                    } else if (childNodeName.equals("service")) {
+                        setService(childNodeTextContent);
+                    } else if (childNodeName.equals("height")) {
+                        setHeight(Integer.valueOf(childNodeTextContent));
+                    } else if (childNodeName.equals("mapping")) {
+                        NodeList mappingChildNodes = childNode.getChildNodes();
+                        String mappingCommand = "";
+                        String mappingLabel = "";
+                        for (int k = 0; k < mappingChildNodes.getLength(); k++) {
+                            if (mappingChildNodes.item(k).getNodeName().equals("command"))
+                                mappingCommand = mappingChildNodes.item(k).getTextContent();
+                            if (mappingChildNodes.item(k).getNodeName().equals("label"))
+                                mappingLabel = mappingChildNodes.item(k).getTextContent();
+                        }
+                        OpenHABWidgetMapping mapping = new OpenHABWidgetMapping(mappingCommand, mappingLabel);
+                        mappings.add(mapping);
+                    } else if (childNodeName.equals("iconcolor")) {
+                        setIconColor(childNodeTextContent);
+                    } else if (childNodeName.equals("labelcolor")) {
+                        setLabelColor(childNodeTextContent);
+                    } else if (childNodeName.equals("valuecolor")) {
+                        setValueColor(childNodeTextContent);
+                    } else if (childNodeName.equals("encoding")) {
+                        setEncoding(childNodeTextContent);
+                    }
+                 }
+            }
+        }
+        this.parent.addChildWidget(this);
+    }
+    public static OpenHABWidget createOpenHABWidgetFromNode(OpenHABWidget parent, Node startNode) {
+        return new OpenHAB1Widget(parent, startNode);
+    }
+
+
+}

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Sitemap.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Sitemap.java
@@ -1,0 +1,47 @@
+package org.openhab.habdroid.model;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class OpenHAB2Sitemap extends OpenHABSitemap {
+    public OpenHAB2Sitemap(JSONObject jsonObject) {
+        try {
+            if (jsonObject.has("name"))
+                this.setName(jsonObject.getString("name"));
+            if (jsonObject.has("label"))
+                this.setLabel(jsonObject.getString("label"));
+            if (jsonObject.has("link"))
+                this.setLink(jsonObject.getString("link"));
+            if (jsonObject.has("icon"))
+                this.setIcon(jsonObject.getString("icon"));
+            if (jsonObject.has("homepage")) {
+                JSONObject homepageObject = jsonObject.getJSONObject("homepage");
+                this.setHomepageLink(homepageObject.getString("link"));
+            }
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static final Parcelable.Creator<OpenHABSitemap> CREATOR = new Parcelable.Creator<OpenHABSitemap>() {
+        public OpenHABSitemap createFromParcel(Parcel in) {
+            return new OpenHAB2Sitemap(in);
+        }
+
+        public OpenHABSitemap[] newArray(int size) {
+            return new OpenHAB2Sitemap[size];
+        }
+    };
+
+    public OpenHAB2Sitemap(Parcel in) {
+        super(in);
+    }
+
+    @Override
+    public String getIconPath() {
+        return String.format("icon/%s", getIcon());
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Widget.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Widget.java
@@ -1,0 +1,92 @@
+package org.openhab.habdroid.model;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+
+public class OpenHAB2Widget extends OpenHABWidget {
+    public OpenHAB2Widget() {
+    }
+
+    @Override
+    public String getIconPath() {
+        OpenHABItem widgetItem = getItem();
+        String itemState = (widgetItem != null) ? widgetItem.getState() : null;
+        return String.format("icon/%s?state=%s", getIcon(), itemState);
+    }
+
+    private OpenHAB2Widget(OpenHABWidget parent, JSONObject widgetJson) {
+        this.parent = parent;
+        this.children = new ArrayList<OpenHABWidget>();
+        this.mappings = new ArrayList<OpenHABWidgetMapping>();
+        try {
+            if (widgetJson.has("item")) {
+                this.setItem(new OpenHABItem(widgetJson.getJSONObject("item")));
+            }
+            if (widgetJson.has("linkedPage")) {
+                this.setLinkedPage(new OpenHABLinkedPage(widgetJson.getJSONObject("linkedPage")));
+            }
+            if (widgetJson.has("mappings")) {
+                JSONArray mappingsJsonArray = widgetJson.getJSONArray("mappings");
+                for (int i=0; i<mappingsJsonArray.length(); i++) {
+                    JSONObject mappingObject = mappingsJsonArray.getJSONObject(i);
+                    OpenHABWidgetMapping mapping = new OpenHABWidgetMapping(mappingObject.getString("command"),
+                            mappingObject.getString("label"));
+                    mappings.add(mapping);
+                }
+            }
+            if (widgetJson.has("type"))
+                this.setType(widgetJson.getString("type"));
+            if (widgetJson.has("widgetId"))
+                this.setId(widgetJson.getString("widgetId"));
+            if (widgetJson.has("label"))
+                this.setLabel(widgetJson.getString("label"));
+            if (widgetJson.has("icon"))
+                this.setIcon(widgetJson.getString("icon"));
+            if (widgetJson.has("url"))
+                this.setUrl(widgetJson.getString("url"));
+            if (widgetJson.has("minValue"))
+                this.setMinValue((float)widgetJson.getDouble("minValue"));
+            if (widgetJson.has("maxValue"))
+                this.setMaxValue((float)widgetJson.getDouble("maxValue"));
+            if (widgetJson.has("step"))
+                this.setStep((float)widgetJson.getDouble("step"));
+            if (widgetJson.has("refresh"))
+                this.setRefresh(widgetJson.getInt("refresh"));
+            if (widgetJson.has("period"))
+                this.setPeriod(widgetJson.getString("period"));
+            if (widgetJson.has("service"))
+                this.setService(widgetJson.getString("service"));
+            if (widgetJson.has("height"))
+                this.setHeight(widgetJson.getInt("height"));
+            if (widgetJson.has("iconcolor"))
+                this.setIconColor(widgetJson.getString("iconcolor"));
+            if (widgetJson.has("labelcolor"))
+                this.setLabelColor(widgetJson.getString("labelcolor"));
+            if (widgetJson.has("valuecolor"))
+                this.setValueColor(widgetJson.getString("valuecolor"));
+            if (widgetJson.has("encoding"))
+                this.setEncoding(widgetJson.getString("encoding"));
+
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        if (widgetJson.has("widgets")) {
+            try {
+                JSONArray childWidgetJsonArray = widgetJson.getJSONArray("widgets");
+                for (int i=0; i<childWidgetJsonArray.length(); i++) {
+                    createOpenHABWidgetFromJson(this, childWidgetJsonArray.getJSONObject(i));
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+        }
+        this.parent.addChildWidget(this);
+    }
+
+    public static OpenHABWidget createOpenHABWidgetFromJson(OpenHABWidget parent, JSONObject widgetJson) {
+        return new OpenHAB2Widget(parent, widgetJson);
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABSitemap.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABSitemap.java
@@ -17,68 +17,15 @@ import org.json.JSONObject;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
-public class OpenHABSitemap implements Parcelable {
+public abstract class OpenHABSitemap implements Parcelable {
 	private String name;
     private String label;
 	private String link;
     private String icon;
 	private String homepageLink;
     private boolean leaf = false;
-	
-	public OpenHABSitemap(Node startNode) {
-		if (startNode.hasChildNodes()) {
-			NodeList childNodes = startNode.getChildNodes();
-			for (int i = 0; i < childNodes.getLength(); i ++) {
-				Node childNode = childNodes.item(i);
-				if (childNode.getNodeName().equals("name")) {
-					this.setName(childNode.getTextContent());
-                } else if (childNode.getNodeName().equals("label")) {
-                    this.setLabel(childNode.getTextContent());
-				} else if (childNode.getNodeName().equals("link")) {
-					this.setLink(childNode.getTextContent());
-                } else if (childNode.getNodeName().equals("icon")) {
-                    this.setIcon(childNode.getTextContent());
-				} else if (childNode.getNodeName().equals("homepage")) {
-					if (childNode.hasChildNodes()) {
-						NodeList homepageNodes = childNode.getChildNodes();
-						for (int j = 0; j < homepageNodes.getLength(); j++) {
-							Node homepageChildNode = homepageNodes.item(j);
-							if (homepageChildNode.getNodeName().equals("link")) {
-								this.setHomepageLink(homepageChildNode.getTextContent());
-							} else if (homepageChildNode.getNodeName().equals("leaf")) {
-                                if (homepageChildNode.getTextContent().equals("true")) {
-                                    setLeaf(true);
-                                } else {
-                                    setLeaf(false);
-                                }
-                            }
-						}
-					}
-				}
-			}
-		}
-	}
 
-    public OpenHABSitemap(JSONObject jsonObject) {
-        try {
-            if (jsonObject.has("name"))
-                this.setName(jsonObject.getString("name"));
-            if (jsonObject.has("label"))
-                this.setLabel(jsonObject.getString("label"));
-            if (jsonObject.has("link"))
-                this.setLink(jsonObject.getString("link"));
-            if (jsonObject.has("icon"))
-                this.setIcon(jsonObject.getString("icon"));
-            if (jsonObject.has("homepage")) {
-                JSONObject homepageObject = jsonObject.getJSONObject("homepage");
-                this.setHomepageLink(homepageObject.getString("link"));
-            }
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private OpenHABSitemap(Parcel in) {
+    OpenHABSitemap(Parcel in) {
         this.name = in.readString();
         this.label = in.readString();
         this.link = in.readString();
@@ -86,7 +33,10 @@ public class OpenHABSitemap implements Parcelable {
         this.homepageLink = in.readString();
     }
 
-	public String getName() {
+    protected OpenHABSitemap() {
+    }
+
+    public String getName() {
 		return name;
 	}
 	public void setName(String name) {
@@ -141,14 +91,6 @@ public class OpenHABSitemap implements Parcelable {
         dest.writeString(homepageLink);
     }
 
-    public static final Parcelable.Creator<OpenHABSitemap> CREATOR = new Parcelable.Creator<OpenHABSitemap>() {
-        public OpenHABSitemap createFromParcel(Parcel in) {
-            return new OpenHABSitemap(in);
-        }
-
-        public OpenHABSitemap[] newArray(int size) {
-            return new OpenHABSitemap[size];
-        }
-    };
+    public abstract String getIconPath();
 
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABSitemapPage.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABSitemapPage.java
@@ -29,14 +29,14 @@ public class OpenHABSitemapPage {
         Node rootNode = document.getFirstChild();
         if (rootNode == null)
             return;
-        mRootWidget = new OpenHABWidget();
+        mRootWidget = new OpenHAB1Widget();
         mRootWidget.setType("root");
         if (rootNode.hasChildNodes()) {
             NodeList childNodes = rootNode.getChildNodes();
             for (int i = 0; i < childNodes.getLength(); i ++) {
                 Node childNode = childNodes.item(i);
                 if (childNode.getNodeName().equals("widget")) {
-                    OpenHABWidget newOpenHABWidget = new OpenHABWidget(mRootWidget, childNode);
+                    OpenHABWidget newOpenHABWidget = OpenHAB1Widget.createOpenHABWidgetFromNode(mRootWidget, childNode);
                     mWidgets.add(newOpenHABWidget);
                 } else if (childNode.getNodeName().equals("title")) {
                     this.setTitle(childNode.getTextContent());
@@ -53,7 +53,6 @@ public class OpenHABSitemapPage {
     }
 
     public OpenHABSitemapPage(JSONObject document) {
-
     }
 
     public ArrayList<OpenHABWidget> getWidgets() {

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABWidget.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABWidget.java
@@ -12,19 +12,13 @@ package org.openhab.habdroid.model;
 import android.graphics.Color;
 import android.util.Log;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
-
 import java.util.ArrayList;
 
 /**
  * This is a class to hold basic information about openHAB widget.
  */
 
-public class OpenHABWidget {
+public abstract class OpenHABWidget {
 	private String id;
 	private String label;
 	private String icon;
@@ -37,11 +31,12 @@ public class OpenHABWidget {
 	private float step = 1;
 	private int refresh = 0;
 	private int height = 0;
-	private OpenHABWidget parent;
+	private String state;
+	OpenHABWidget parent;
 	private OpenHABItem item;
 	private OpenHABLinkedPage linkedPage;
-	private ArrayList<OpenHABWidget> children;
-	private ArrayList<OpenHABWidgetMapping> mappings;
+	ArrayList<OpenHABWidget> children;
+	ArrayList<OpenHABWidgetMapping> mappings;
     private boolean mChildrenHasLinkedPages = false;
     private Integer iconcolor;
     private Integer labelcolor;
@@ -52,141 +47,7 @@ public class OpenHABWidget {
 		this.children = new ArrayList<OpenHABWidget>();
 		this.mappings = new ArrayList<OpenHABWidgetMapping>();
 	}
-	
-	public OpenHABWidget(OpenHABWidget parent, Node startNode) {
-		this.parent = parent;
-		this.children = new ArrayList<OpenHABWidget>();
-		this.mappings = new ArrayList<OpenHABWidgetMapping>();
-		if (startNode.hasChildNodes()) {
-			NodeList childNodes = startNode.getChildNodes();
-			for (int i = 0; i < childNodes.getLength(); i ++) {
-				Node childNode = childNodes.item(i);
-				if (childNode.getNodeName().equals("item")) {
-					this.setItem(new OpenHABItem(childNode));
-				} else if (childNode.getNodeName().equals("linkedPage")) {					
-					this.setLinkedPage(new OpenHABLinkedPage(childNode));
-				} else if (childNode.getNodeName().equals("widget")) {
-					new OpenHABWidget(this, childNode);
-				} else {
-					if (childNode.getNodeName().equals("type")) {
-						this.setType(childNode.getTextContent());
-					} else if (childNode.getNodeName().equals("widgetId")) {
-						this.setId(childNode.getTextContent());
-					} else if (childNode.getNodeName().equals("label")) {
-						this.setLabel(childNode.getTextContent());
-					} else if (childNode.getNodeName().equals("icon")) {
-						this.setIcon(childNode.getTextContent());
-					} else if (childNode.getNodeName().equals("url")) {
-						this.setUrl(childNode.getTextContent());
-					} else if (childNode.getNodeName().equals("minValue")) {
-						setMinValue(Float.valueOf(childNode.getTextContent()).floatValue());
-					} else if (childNode.getNodeName().equals("maxValue")) {
-						setMaxValue(Float.valueOf(childNode.getTextContent()).floatValue());
-					} else if (childNode.getNodeName().equals("step")) {
-						setStep(Float.valueOf(childNode.getTextContent()).floatValue());
-					} else if (childNode.getNodeName().equals("refresh")) {
-						setRefresh(Integer.valueOf(childNode.getTextContent()).intValue());
-					} else if (childNode.getNodeName().equals("period")) {
-						setPeriod(childNode.getTextContent());
-                    } else if (childNode.getNodeName().equals("service")) {
-                        setService(childNode.getTextContent());
-                    } else if (childNode.getNodeName().equals("height")) {
-						setHeight(Integer.valueOf(childNode.getTextContent()));
-					} else if (childNode.getNodeName().equals("mapping")) {
-						NodeList mappingChildNodes = childNode.getChildNodes();
-						String mappingCommand = "";
-						String mappingLabel = "";
-						for (int k = 0; k < mappingChildNodes.getLength(); k++) {
-							if (mappingChildNodes.item(k).getNodeName().equals("command"))
-								mappingCommand = mappingChildNodes.item(k).getTextContent();
-							if (mappingChildNodes.item(k).getNodeName().equals("label"))
-								mappingLabel = mappingChildNodes.item(k).getTextContent();
-						}
-						OpenHABWidgetMapping mapping = new OpenHABWidgetMapping(mappingCommand, mappingLabel);
-						mappings.add(mapping);
-					} else if (childNode.getNodeName().equals("iconcolor")) {
-                        setIconColor(childNode.getTextContent());
-                    } else if (childNode.getNodeName().equals("labelcolor")) {
-                        setLabelColor(childNode.getTextContent());
-                    } else if (childNode.getNodeName().equals("valuecolor")) {
-                        setValueColor(childNode.getTextContent());
-                    } else if (childNode.getNodeName().equals("encoding")) {
-                        setEncoding(childNode.getTextContent());
-                    }
-				}
-			}
-		}
-		this.parent.addChildWidget(this);
-	}
 
-    public OpenHABWidget(OpenHABWidget parent, JSONObject widgetJson) {
-        this.parent = parent;
-        this.children = new ArrayList<OpenHABWidget>();
-        this.mappings = new ArrayList<OpenHABWidgetMapping>();
-        try {
-            if (widgetJson.has("item")) {
-                this.setItem(new OpenHABItem(widgetJson.getJSONObject("item")));
-            }
-            if (widgetJson.has("linkedPage")) {
-                this.setLinkedPage(new OpenHABLinkedPage(widgetJson.getJSONObject("linkedPage")));
-            }
-            if (widgetJson.has("mappings")) {
-                JSONArray mappingsJsonArray = widgetJson.getJSONArray("mappings");
-                for (int i=0; i<mappingsJsonArray.length(); i++) {
-                    JSONObject mappingObject = mappingsJsonArray.getJSONObject(i);
-                    OpenHABWidgetMapping mapping = new OpenHABWidgetMapping(mappingObject.getString("command"),
-                            mappingObject.getString("label"));
-                    mappings.add(mapping);
-                }
-            }
-            if (widgetJson.has("type"))
-                this.setType(widgetJson.getString("type"));
-            if (widgetJson.has("widgetId"))
-                this.setId(widgetJson.getString("widgetId"));
-            if (widgetJson.has("label"))
-                this.setLabel(widgetJson.getString("label"));
-            if (widgetJson.has("icon"))
-                this.setIcon(widgetJson.getString("icon"));
-            if (widgetJson.has("url"))
-                this.setUrl(widgetJson.getString("url"));
-            if (widgetJson.has("minValue"))
-                this.setMinValue((float)widgetJson.getDouble("minValue"));
-            if (widgetJson.has("maxValue"))
-                this.setMaxValue((float)widgetJson.getDouble("maxValue"));
-            if (widgetJson.has("step"))
-                this.setStep((float)widgetJson.getDouble("step"));
-            if (widgetJson.has("refresh"))
-                this.setRefresh(widgetJson.getInt("refresh"));
-            if (widgetJson.has("period"))
-                this.setPeriod(widgetJson.getString("period"));
-            if (widgetJson.has("service"))
-                this.setService(widgetJson.getString("service"));
-            if (widgetJson.has("height"))
-                this.setHeight(widgetJson.getInt("height"));
-            if (widgetJson.has("iconcolor"))
-                this.setIconColor(widgetJson.getString("iconcolor"));
-            if (widgetJson.has("labelcolor"))
-                this.setLabelColor(widgetJson.getString("labelcolor"));
-            if (widgetJson.has("valuecolor"))
-                this.setValueColor(widgetJson.getString("valuecolor"));
-            if (widgetJson.has("encoding"))
-                this.setEncoding(widgetJson.getString("encoding"));
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-        if (widgetJson.has("widgets")) {
-            try {
-                JSONArray childWidgetJsonArray = widgetJson.getJSONArray("widgets");
-                for (int i=0; i<childWidgetJsonArray.length(); i++) {
-                    new OpenHABWidget(this, childWidgetJsonArray.getJSONObject(i));
-                }
-            } catch (JSONException e) {
-                e.printStackTrace();
-            }
-        }
-        this.parent.addChildWidget(this);
-    }
-	
 	public void addChildWidget(OpenHABWidget child) {
 		if (child != null) {
 			this.children.add(child);
@@ -422,4 +283,14 @@ public class OpenHABWidget {
     public void setEncoding(String encoding) {
         this.encoding = encoding;
     }
+
+	public void setState(String state) {
+		this.state = state;
+	}
+
+	public String getState() {
+		return state;
+	}
+
+	public abstract String getIconPath();
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABWidgetDataSource.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABWidgetDataSource.java
@@ -48,14 +48,14 @@ public class OpenHABWidgetDataSource {
 		Log.i(TAG, "Loading new data");
         if (rootNode == null)
             return;
-		rootWidget = new OpenHABWidget();
+		rootWidget = new OpenHAB1Widget();
 		rootWidget.setType("root");
 		if (rootNode.hasChildNodes()) {
 			NodeList childNodes = rootNode.getChildNodes();
 			for (int i = 0; i < childNodes.getLength(); i ++) {
 				Node childNode = childNodes.item(i);
 				if (childNode.getNodeName().equals("widget")) {
-					new OpenHABWidget(rootWidget, childNode);
+					OpenHAB1Widget.createOpenHABWidgetFromNode(rootWidget, childNode);
 				} else if (childNode.getNodeName().equals("title")) {
 					this.setTitle(childNode.getTextContent());
 				} else if (childNode.getNodeName().equals("id")) {
@@ -73,14 +73,14 @@ public class OpenHABWidgetDataSource {
         Log.d(TAG, jsonObject.toString());
         if (!jsonObject.has("widgets"))
             return;
-        rootWidget = new OpenHABWidget();
+        rootWidget = new OpenHAB2Widget();
         rootWidget.setType("root");
         try {
             JSONArray jsonWidgetArray = jsonObject.getJSONArray("widgets");
             for (int i=0; i<jsonWidgetArray.length(); i++) {
                 JSONObject widgetJson = jsonWidgetArray.getJSONObject(i);
                 // Log.d(TAG, widgetJson.toString());
-                new OpenHABWidget(rootWidget, widgetJson);
+                OpenHAB2Widget.createOpenHABWidgetFromJson(rootWidget, widgetJson);
             }
             if (jsonObject.has("title"))
                 this.setTitle(jsonObject.getString("title"));

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -21,7 +21,6 @@ import android.view.View.OnTouchListener;
 import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.webkit.WebView;
-import android.webkit.WebViewClient;
 import android.widget.AdapterView;
 import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.ArrayAdapter;
@@ -38,7 +37,6 @@ import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.VideoView;
 
-import com.crittercism.app.Crittercism;
 import com.loopj.android.http.AsyncHttpClient;
 import com.loopj.android.http.TextHttpResponseHandler;
 
@@ -184,17 +182,16 @@ public class OpenHABWidgetAdapter extends ArrayAdapter<OpenHABWidget> {
         MySmartImageView widgetImage = (MySmartImageView)widgetView.findViewById(R.id.widgetimage);
         // Some of widgets, for example Frame doesnt' have an icon, so...
         if (widgetImage != null) {
-            if (openHABWidget.getIcon() != null) {
-                // This is needed to escape possible spaces and everything according to rfc2396
-                String iconUrl = openHABBaseUrl + "images/" + Uri.encode(openHABWidget.getIcon() + ".png");
+            // This is needed to escape possible spaces and everything according to rfc2396
+            String iconUrl = openHABBaseUrl + Uri.encode(openHABWidget.getIconPath(),"/?=");
 //                Log.d(TAG, "Will try to load icon from " + iconUrl);
-                // Now set image URL
-                widgetImage.setImageUrl(iconUrl, R.drawable.blank_icon,
-                        openHABUsername, openHABPassword);
-                if(iconColor != null)
-                    widgetImage.setColorFilter(iconColor);
-                else
-                    widgetImage.clearColorFilter();
+            // Now set image URL
+            widgetImage.setImageUrl(iconUrl, R.drawable.blank_icon,
+                    openHABUsername, openHABPassword);
+            if (iconColor != null) {
+                widgetImage.setColorFilter(iconColor);
+            } else {
+                widgetImage.clearColorFilter();
             }
         }
         TextView defaultTextView = new TextView(widgetView.getContext());

--- a/mobile/src/main/java/org/openhab/habdroid/ui/drawer/OpenHABDrawerAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/drawer/OpenHABDrawerAdapter.java
@@ -24,6 +24,7 @@ import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.model.OpenHABSitemap;
 import org.openhab.habdroid.util.MySmartImageView;
 
 import java.util.List;
@@ -92,17 +93,17 @@ public class OpenHABDrawerAdapter extends ArrayAdapter<OpenHABDrawerItem> {
         drawerItemImage = (MySmartImageView)drawerItemView.findViewById(R.id.itemimage);
         switch (this.getItemViewType(position)) {
             case TYPE_SITEMAPITEM:
-                if (drawerItem.getSiteMap().getLabel() != null && drawerItemLabelTextView != null) {
-                    drawerItemLabelTextView.setText(drawerItem.getSiteMap().getLabel());
+                OpenHABSitemap siteMap = drawerItem.getSiteMap();
+                if (siteMap.getLabel() != null && drawerItemLabelTextView != null) {
+                    drawerItemLabelTextView.setText(siteMap.getLabel());
                 } else {
-                    drawerItemLabelTextView.setText(drawerItem.getSiteMap().getName());
+                    drawerItemLabelTextView.setText(siteMap.getName());
                 }
-                if (drawerItem.getSiteMap().getIcon() != null && drawerItemImage != null) {
-                    String iconUrl = openHABBaseUrl + "images/" + Uri.encode(drawerItem.getSiteMap().getIcon() + ".png");
+                if (siteMap.getIcon() != null && drawerItemImage != null) {
+                    String iconUrl = openHABBaseUrl + Uri.encode(siteMap.getIconPath(),"/?=");
                     drawerItemImage.setImageUrl(iconUrl, R.drawable.openhabiconsmall,
                             openHABUsername, openHABPassword);
                 } else {
-                    String iconUrl = openHABBaseUrl + "images/" + ".png";
                     drawerItemImage.setImageDrawable(getContext().getResources().getDrawable(R.drawable.openhabicon_light));
                 }
                 break;

--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -22,6 +22,8 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.model.OpenHAB1Sitemap;
+import org.openhab.habdroid.model.OpenHAB2Sitemap;
 import org.openhab.habdroid.model.OpenHABSitemap;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
@@ -77,7 +79,7 @@ public class Util {
         if (sitemapNodes.getLength() > 0) {
             for (int i = 0; i < sitemapNodes.getLength(); i++) {
                 Node sitemapNode = sitemapNodes.item(i);
-                OpenHABSitemap openhabSitemap = new OpenHABSitemap(sitemapNode);
+                OpenHABSitemap openhabSitemap = new OpenHAB1Sitemap(sitemapNode);
                 sitemapList.add(openhabSitemap);
             }
         }
@@ -89,7 +91,7 @@ public class Util {
         for (int i = 0; i < jsonArray.length(); i++) {
             try {
                 JSONObject sitemapJson = jsonArray.getJSONObject(i);
-                OpenHABSitemap openHABSitemap = new OpenHABSitemap(sitemapJson);
+                OpenHABSitemap openHABSitemap = new OpenHAB2Sitemap(sitemapJson);
                 sitemapList.add(openHABSitemap);
             } catch (JSONException e) {
                 e.printStackTrace();

--- a/mobile/src/test/java/org/openhab/habdroid/model/OpenHAB1WidgetTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/model/OpenHAB1WidgetTest.java
@@ -1,0 +1,81 @@
+package org.openhab.habdroid.model;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import org.xml.sax.InputSource;
+
+import java.io.StringReader;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OpenHAB1WidgetTest {
+    OpenHABWidget rootWidget = mock(OpenHAB1Widget.class);
+
+    @Test
+    public void createOpenHABWidgetFromNode_createsOpenHAB1Widget() throws Exception {
+        OpenHABWidget sut = OpenHAB1Widget.createOpenHABWidgetFromNode(rootWidget, createXmlNode());
+        assertTrue(sut instanceof OpenHAB1Widget);
+    }
+
+    @Test
+    public void getIconPath_iconExists_returnIconUrlfromImages() throws Exception {
+        OpenHABWidget sut = OpenHAB1Widget.createOpenHABWidgetFromNode(rootWidget, createXmlNode());
+        assertEquals("images/groupicon.png", sut.getIconPath());
+    }
+
+    private Node createXmlNode() throws Exception {
+        String xml = "" +
+                "<widget>" +
+                "  <widgetId>demo</widgetId>" +
+                "  <type>Group</type>" +
+                "  <label>Group1</label>" +
+                "  <icon>groupicon</icon>" +
+                "  <url>http://localhost/url</url>" +
+                "  <minValue>0.0</minValue>" +
+                "  <maxValue>10.0</maxValue>" +
+                "  <step>1</step>" +
+                "  <refresh>10</refresh>" +
+                "  <period>D</period>" +
+                "  <service>D</service>" +
+                "  <height>10</height>" +
+                "  <iconcolor>white</iconcolor>" +
+                "  <labelcolor>white</labelcolor>" +
+                "  <valuecolor>white</valuecolor>" +
+                "  <encoding></encoding>" +
+                "  <mapping>" +
+                "    <command>ON</command>\n" +
+                "    <label>On</label>" +
+                "  </mapping>" +
+                "  <item>" +
+                "    <type>GroupItem</type>" +
+                "    <name>group1</name>" +
+                "    <state>Undefined</state>" +
+                "    <link>http://localhost/rest/items/group1</link>" +
+                "  </item>" +
+                "  <linkedPage>" +
+                "    <id>0001</id>" +
+                "    <title>LinkedPage</title>" +
+                "    <icon>linkedpageicon</icon>" +
+                "    <link>http://localhost/rest/sitemaps/demo/0001</link>" +
+                "    <leaf>false</leaf>" +
+                "  </linkedPage>" +
+                "  <widget>" +
+                "    <widgetId>demo11</widgetId>" +
+                "  </widget>" +
+                "</widget>";
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        DocumentBuilder builder = dbf.newDocumentBuilder();
+        Document document = builder.parse(new InputSource(new StringReader(xml)));
+        Node rootNode = document.getFirstChild();
+        return rootNode;
+    }
+}

--- a/mobile/src/test/java/org/openhab/habdroid/model/OpenHAB2WidgetTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/model/OpenHAB2WidgetTest.java
@@ -1,0 +1,67 @@
+package org.openhab.habdroid.model;
+
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class OpenHAB2WidgetTest {
+    OpenHABWidget rootWidget = mock(OpenHAB2Widget.class);
+
+    @Test
+    public void getIconPath_iconExists_returnIconUrlToIconServlet() throws Exception {
+        OpenHABWidget sut = OpenHAB2Widget.createOpenHABWidgetFromJson(rootWidget, createJSONObject());
+        assertEquals("icon/groupicon?state=OFF", sut.getIconPath());
+    }
+
+    @Test
+    public void testCreateOpenHABWidgetFromJson_createsOpenHAB2Widget() throws Exception {
+        OpenHABWidget sut = OpenHAB2Widget.createOpenHABWidgetFromJson(rootWidget, createJSONObject());
+        assertTrue(sut instanceof OpenHAB2Widget);
+    }
+
+    private JSONObject createJSONObject() throws Exception {
+
+        String json = "{\n" +
+                "    \"widgetId\": \"demo\",\n" +
+                "    \"type\": \"Group\",\n" +
+                "    \"label\": \"Group1\",\n" +
+                "    \"icon\": \"groupicon\",\n" +
+                "    \"url\": \"http://localhost/url\",\n" +
+                "    \"minValue\": \"0.0\",\n" +
+                "    \"maxValue\": \"10.0\",\n" +
+                "    \"step\": \"1\",\n" +
+                "    \"refresh\": \"10\",\n" +
+                "    \"period\": \"D\",\n" +
+                "    \"service\": \"D\",\n" +
+                "    \"height\": \"10\",\n" +
+                "    \"iconcolor\": \"white\",\n" +
+                "    \"labelcolor\": \"white\",\n" +
+                "    \"valuecolor\": \"white\",\n" +
+                "    \"mappings\": [{\n" +
+                "      \"command\": \"ON\",\n" +
+                "      \"label\": \"On\"\n" +
+                "    }],\n" +
+                "    \"item\": {\n" +
+                "      \"type\": \"GroupItem\",\n" +
+                "      \"name\": \"group1\",\n" +
+                "      \"state\": \"OFF\",\n" +
+                "      \"link\": \"http://localhost/rest/items/group1\"\n" +
+                "    },\n" +
+                "    \"linkedPage\": {\n" +
+                "      \"id\": \"0001\",\n" +
+                "      \"title\": \"LinkedPage\",\n" +
+                "      \"icon\": \"linkedpageicon\",\n" +
+                "      \"link\": \"http://localhost/rest/sitemaps/demo/0001\",\n" +
+                "      \"leaf\": \"false\"\n" +
+                "    },\n" +
+                "    \"widgets\": [{ \"widgetId\": \"demo11\" }]\n" +
+                "  }";
+        return new JSONObject(json);
+    }
+}


### PR DESCRIPTION
When using OpenHAB2, fetch icons from the ESH icon servlet.
Add an abstract method getIconPath() to OpenHABWidget and
OpenHABSitemap that will fetch the correct path for the
server side icon, it will behave differently depending on
OpenHAB version.

Use factory method when creating OpenHABWidgets instead of
a constructor.

Add testCompile dependency to org.json to be able to stub
JSONObject.

Fixes #145

Signed-off-by: Hans Hazelius <hans@hazelius.se>