### PR TITLE
Sort the sitemaps in drawer by label.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/Util.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Util.java
@@ -32,6 +32,8 @@ import org.w3c.dom.NodeList;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 public class Util {
@@ -83,6 +85,14 @@ public class Util {
                 sitemapList.add(openhabSitemap);
             }
         }
+        // Sort by sitename label
+        Collections.sort(sitemapList, new Comparator<OpenHABSitemap>() {
+            @Override
+            public int compare(OpenHABSitemap sitemap1, OpenHABSitemap sitemap2) {
+                return  sitemap1.getLabel().compareTo(sitemap2.getLabel());
+            }
+        });
+
         return sitemapList;
     }
 


### PR DESCRIPTION
I have >30 sitemaps. It's difficult to find the one i'm looking for, because the sitemaps in the drawer are completely unsorted.

This patch sorts the Openhab1 sitemaps by label.
