### PR TITLE
Update info fragment for openHAB 2

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -872,6 +872,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                 bundle.putString(OpenHABVoiceService.OPENHAB_BASE_URL_EXTRA, openHABBaseUrl);
                 bundle.putString("username", openHABUsername);
                 bundle.putString("password", openHABPassword);
+                bundle.putInt("openHABVersion", mOpenHABVersion);
 
                 FragmentManager fm = getSupportFragmentManager();
                 Fragment openHabInfo = new OpenHABInfoFragment();

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="info_write_tag_unsupported">This device doesn\'t have NFC support :-(</string>
     <string name="info_write_tag_disabled">NFC is disabled. Please enable it in device settings menu.</string>
     <string name="info_openhab_version_label">openHAB Version</string>
+    <string name="info_openhab_apiversion_label">openHAB Rest API Version</string>
     <string name="info_openhab_uuid_label">openHAB UUID</string>
     <string name="info_openhab_secret_label">openHAB Secret</string>
     <string name="action_settings">Settings</string>


### PR DESCRIPTION
Fetch uuid and api version from openHAB2
and display them in the info dialog.

Fixes #191

Signed-off-by: Hans Hazelius <hans@hazelius.se>