### PR TITLE
Fix display of charts for group items

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -487,7 +487,7 @@ public class OpenHABWidgetAdapter extends ArrayAdapter<OpenHABWidget> {
     		Random random = new Random();
     		String chartUrl = "";
     		if (chartItem != null) {
-	    		if (chartItem.getType().equals("GroupItem")) {
+	    		if (chartItem.getType().equals("GroupItem") || chartItem.getType().equals("Group")) {
 	    			chartUrl = openHABBaseUrl + "chart?groups=" + chartItem.getName() +
 	    					"&period=" + openHABWidget.getPeriod() + "&random=" +
 	    					String.valueOf(random.nextInt());


### PR DESCRIPTION
Fixes the display of charts in case a group item is to be dislayed (see https://community.openhab.org/t/no-rrd4j-persistence-items-available-via-rest-access-and-in-habdroid/14189)

Signed-off-by: Dominic Lerbs <dominicdesu@hallojapan.de>