### PR TITLE
Collapse duplicate exception catches

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -533,11 +533,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                         DocumentBuilder builder = dbf.newDocumentBuilder();
                         Document sitemapsXml = builder.parse(new ByteArrayInputStream(responseBody));
                         mSitemapList.addAll(Util.parseSitemapList(sitemapsXml));
-                    } catch (ParserConfigurationException e) {
-                        e.printStackTrace();
-                    } catch (SAXException e) {
-                        e.printStackTrace();
-                    } catch (IOException e) {
+                    } catch (ParserConfigurationException | SAXException | IOException e) {
                         e.printStackTrace();
                     }
                     // Later versions work with JSON
@@ -547,9 +543,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                         JSONArray jsonArray = new JSONArray(jsonString);
                         mSitemapList.addAll(Util.parseSitemapList(jsonArray));
                         Log.d(TAG, jsonArray.toString());
-                    } catch (UnsupportedEncodingException e) {
-                        e.printStackTrace();
-                    } catch (JSONException e) {
+                    } catch (UnsupportedEncodingException | JSONException e) {
                         e.printStackTrace();
                     }
                 }
@@ -620,11 +614,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                         DocumentBuilder builder = dbf.newDocumentBuilder();
                         Document sitemapsXml = builder.parse(new ByteArrayInputStream(responseBody));
                         mSitemapList.addAll(Util.parseSitemapList(sitemapsXml));
-                    } catch (ParserConfigurationException e) {
-                        e.printStackTrace();
-                    } catch (SAXException e) {
-                        e.printStackTrace();
-                    } catch (IOException e) {
+                    } catch (ParserConfigurationException | SAXException | IOException e) {
                         e.printStackTrace();
                     }
                     // Later versions work with JSON
@@ -634,9 +624,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                         JSONArray jsonArray = new JSONArray(jsonString);
                         mSitemapList.addAll(Util.parseSitemapList(jsonArray));
                         Log.d(TAG, jsonArray.toString());
-                    } catch (UnsupportedEncodingException e) {
-                        e.printStackTrace();
-                    } catch (JSONException e) {
+                    } catch (UnsupportedEncodingException | JSONException e) {
                         e.printStackTrace();
                     }
                 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWriteTagActivity.java
@@ -159,14 +159,9 @@ public class OpenHABWriteTagActivity extends Activity {
 				ndefFormatable.close();
 			    writeTagMessage.setText(R.string.info_write_tag_finished);
 			    autoCloseActivity();
-			} catch (IOException e) {
-				// TODO Auto-generated catch block
+			} catch (IOException | FormatException e) {
 				if (e.getMessage() != null)
 					Log.e(TAG, e.getMessage());
-				writeTagMessage.setText(R.string.info_write_failed);
-			} catch (FormatException e) {
-				// TODO Auto-generated catch block
-				Log.e(TAG, e.getMessage());
 				writeTagMessage.setText(R.string.info_write_failed);
 			}
 		} else {


### PR DESCRIPTION
these catches are identical, and probably generated by an editor at some stage. Collapsing them to make the code easier to read.
