### PR TITLE
Support for icons in svg format

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -35,6 +35,10 @@ repositories {
         name "OpenHAB"
         url "http://repository-openhab.forge.cloudbees.com/release/"
     }
+    maven {
+        url 'https://jitpack.io'
+    }
+
 }
 
 dependencies {
@@ -52,6 +56,8 @@ dependencies {
     compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'com.loopj:android-smart-image-view:1.0.0'
     compile 'com.github.shell-software:fab:1.1.0'
+
+    compile 'com.github.hazzeh:androidsvg:fix-npe'
 
     testCompile 'org.mockito:mockito-core:1.10.19'
     testCompile 'junit:junit:4.12'

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Widget.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Widget.java
@@ -7,17 +7,22 @@ import org.json.JSONObject;
 import java.util.ArrayList;
 
 public class OpenHAB2Widget extends OpenHABWidget {
+
+    private String iconFormat;
+
     public OpenHAB2Widget() {
+        iconFormat="null";
     }
 
     @Override
     public String getIconPath() {
         OpenHABItem widgetItem = getItem();
         String itemState = (widgetItem != null) ? widgetItem.getState() : null;
-        return String.format("icon/%s?state=%s", getIcon(), itemState);
+        return String.format("icon/%s?state=%s&format=%s", getIcon(), itemState, iconFormat);
     }
 
-    private OpenHAB2Widget(OpenHABWidget parent, JSONObject widgetJson) {
+    private OpenHAB2Widget(OpenHABWidget parent, JSONObject widgetJson, String iconFormat) {
+        this.iconFormat = iconFormat;
         this.parent = parent;
         this.children = new ArrayList<OpenHABWidget>();
         this.mappings = new ArrayList<OpenHABWidgetMapping>();
@@ -77,7 +82,7 @@ public class OpenHAB2Widget extends OpenHABWidget {
             try {
                 JSONArray childWidgetJsonArray = widgetJson.getJSONArray("widgets");
                 for (int i=0; i<childWidgetJsonArray.length(); i++) {
-                    createOpenHABWidgetFromJson(this, childWidgetJsonArray.getJSONObject(i));
+                    createOpenHABWidgetFromJson(this, childWidgetJsonArray.getJSONObject(i), iconFormat);
                 }
             } catch (JSONException e) {
                 e.printStackTrace();
@@ -86,7 +91,7 @@ public class OpenHAB2Widget extends OpenHABWidget {
         this.parent.addChildWidget(this);
     }
 
-    public static OpenHABWidget createOpenHABWidgetFromJson(OpenHABWidget parent, JSONObject widgetJson) {
-        return new OpenHAB2Widget(parent, widgetJson);
+    public static OpenHABWidget createOpenHABWidgetFromJson(OpenHABWidget parent, JSONObject widgetJson, String iconFormat) {
+        return new OpenHAB2Widget(parent, widgetJson, iconFormat);
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABWidgetDataSource.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABWidgetDataSource.java
@@ -26,23 +26,16 @@ import java.util.ArrayList;
 
 public class OpenHABWidgetDataSource {
 	private static final String TAG = OpenHABWidgetDataSource.class.getSimpleName();
+	private final String iconFormat;
 	private OpenHABWidget rootWidget;
 	private String title;
 	private String id;
 	private String icon;
 	private String link;
 
-	public OpenHABWidgetDataSource() {
-		
+	public OpenHABWidgetDataSource(String iconFormat) {
+		this.iconFormat = iconFormat;
 	}
-	
-	public OpenHABWidgetDataSource(Node rootNode) {
-		setSourceNode(rootNode);
-	}
-
-    public OpenHABWidgetDataSource(JSONObject jsonObject) {
-        setSourceJson(jsonObject);
-    }
 
 	public void setSourceNode(Node rootNode) {
 		Log.i(TAG, "Loading new data");
@@ -80,7 +73,7 @@ public class OpenHABWidgetDataSource {
             for (int i=0; i<jsonWidgetArray.length(); i++) {
                 JSONObject widgetJson = jsonWidgetArray.getJSONObject(i);
                 // Log.d(TAG, widgetJson.toString());
-                OpenHAB2Widget.createOpenHABWidgetFromJson(rootWidget, widgetJson);
+                OpenHAB2Widget.createOpenHABWidgetFromJson(rootWidget, widgetJson, iconFormat);
             }
             if (jsonObject.has("title"))
                 this.setTitle(jsonObject.getString("title"));

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -183,7 +183,7 @@ public class OpenHABWidgetAdapter extends ArrayAdapter<OpenHABWidget> {
         // Some of widgets, for example Frame doesnt' have an icon, so...
         if (widgetImage != null) {
             // This is needed to escape possible spaces and everything according to rfc2396
-            String iconUrl = openHABBaseUrl + Uri.encode(openHABWidget.getIconPath(),"/?=");
+            String iconUrl = openHABBaseUrl + Uri.encode(openHABWidget.getIconPath(),"/?=&");
 //                Log.d(TAG, "Will try to load icon from " + iconUrl);
             // Now set image URL
             widgetImage.setImageUrl(iconUrl, R.drawable.blank_icon,

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
@@ -15,6 +15,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
+import android.preference.PreferenceManager;
 import android.support.v4.app.ListFragment;
 import android.text.TextUtils;
 import android.util.Log;
@@ -139,7 +140,8 @@ public class OpenHABWidgetListFragment extends ListFragment {
         Log.d(TAG, "onActivityCreated()");
         Log.d(TAG, "isAdded = " + isAdded());
         mActivity = (OpenHABMainActivity)getActivity();
-        openHABWidgetDataSource = new OpenHABWidgetDataSource();
+        final String iconFormat = PreferenceManager.getDefaultSharedPreferences(mActivity).getString("iconFormatType","PNG");
+        openHABWidgetDataSource = new OpenHABWidgetDataSource(iconFormat);
         openHABWidgetAdapter = new OpenHABWidgetAdapter(getActivity(),
                 R.layout.openhabwidgetlist_genericitem, widgetList);
         getListView().setAdapter(openHABWidgetAdapter);

--- a/mobile/src/main/res/values/arrays.xml
+++ b/mobile/src/main/res/values/arrays.xml
@@ -19,4 +19,8 @@
         <item>@string/theme_value_black</item>
     </string-array>
 
+    <string-array name="iconTypeValues">
+        <item>PNG</item>
+        <item>SVG</item>
+    </string-array>
 </resources>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -81,6 +81,12 @@
             android:key="default_openhab_fullscreen"
             android:summary="@string/settings_openhab_fullscreen_summary"
             android:title="@string/settings_openhab_fullscreen" />
+        <ListPreference android:title="Icon format"
+            android:key="iconFormatType"
+            android:defaultValue="PNG"
+            android:summary="%s"
+            android:entries="@array/iconTypeValues"
+            android:entryValues="@array/iconTypeValues" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_misc_title">
         <RingtonePreference

--- a/mobile/src/test/java/org/openhab/habdroid/model/OpenHAB2WidgetTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/model/OpenHAB2WidgetTest.java
@@ -15,13 +15,13 @@ public class OpenHAB2WidgetTest {
 
     @Test
     public void getIconPath_iconExists_returnIconUrlToIconServlet() throws Exception {
-        OpenHABWidget sut = OpenHAB2Widget.createOpenHABWidgetFromJson(rootWidget, createJSONObject());
-        assertEquals("icon/groupicon?state=OFF", sut.getIconPath());
+        OpenHABWidget sut = OpenHAB2Widget.createOpenHABWidgetFromJson(rootWidget, createJSONObject(), "PNG");
+        assertEquals("icon/groupicon?state=OFF&format=PNG", sut.getIconPath());
     }
 
     @Test
     public void testCreateOpenHABWidgetFromJson_createsOpenHAB2Widget() throws Exception {
-        OpenHABWidget sut = OpenHAB2Widget.createOpenHABWidgetFromJson(rootWidget, createJSONObject());
+        OpenHABWidget sut = OpenHAB2Widget.createOpenHABWidgetFromJson(rootWidget, createJSONObject(), "PNG");
         assertTrue(sut instanceof OpenHAB2Widget);
     }
 


### PR DESCRIPTION
Add support for icons in svg format. 
Add use a bugfixed copy of androidsvg from https://github.com/BigBadaboom/androidsvg.
When androidsvg is corrected the copied classes can be replaces with a dependency to the official library instead.