### PR TITLE
Improve WebView compatibility by enabling DOM storage

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -552,6 +552,7 @@ public class OpenHABWidgetAdapter extends ArrayAdapter<OpenHABWidget> {
     			webWeb.setLayoutParams(webLayoutParams);
     		}
     		webWeb.setWebViewClient(new AnchorWebViewClient(openHABWidget.getUrl(), this.openHABUsername, this.openHABPassword));
+            webWeb.getSettings().setDomStorageEnabled(true);
             webWeb.getSettings().setJavaScriptEnabled(true);
     		webWeb.loadUrl(openHABWidget.getUrl());
     	break;


### PR DESCRIPTION
By default the WebView is not 100% HTML5 compatible. This PR enables [DOM storage](https://en.wikipedia.org/wiki/Web_storage) which is for instance required when you want to create a WebView showing a [Grafana](https://community.openhab.org/t/influxdb-grafana-persistence-and-graphing) panel with tooltip support (JavaScript). 