### PR TITLE
References #117 - restore NFC functionality to Switch items

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABNFCActionList.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABNFCActionList.java
@@ -28,7 +28,9 @@ public class OpenHABNFCActionList {
 					actionCommands.add(openHABWidget.getMappings().get(i).getCommand());
 				}
 			} else if (openHABWidget.getType().equals("Switch")) {
-				if (openHABWidget.getItem().getType().equals("SwitchItem")) {
+				//SwitchItem changed to Switch in later builds of OH2
+				if (openHABWidget.getItem().getType().equals("SwitchItem") ||
+						"Switch".equals(openHABWidget.getItem().getType())) {
 					actionNames.add("On");
 					actionCommands.add("ON");
 					actionNames.add("Off");


### PR DESCRIPTION
This change restores the ability to select an NFC option after a long press on a Switch item. 

The type is currently checked to match "SwitchItem" but the actual type value is "Switch" so I modified the if logic to check for both variations.

Issue #117 has a lot of comments, so I'm not sure if this will complete it. At the least, it is part of the solution.

Signed-off-by: Gregory Moyer <moyerg@syphr.com>