### PR TITLE
Update to latest API+tools+gradle+misc.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.4.0-alpha3'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.3.0-beta4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-rc1'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0-beta4'
+        classpath 'com.android.tools.build:gradle:2.3.0-rc1'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.4-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Sep 22 13:28:04 NZST 2016
+#Wed Feb 15 13:56:37 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion '21.1.2'
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
         applicationId "org.openhab.habdroid"
-        minSdkVersion 15
-        targetSdkVersion 22
+        minSdkVersion 14
+        targetSdkVersion 25
         multiDexEnabled = true
     }
     buildTypes {
@@ -17,10 +17,12 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             buildConfigField 'boolean', IS_DEVELOPER, 'false'
+            buildConfigField "java.util.Date", "buildTime", "new java.util.Date(" + System.currentTimeMillis() + "L)"
         }
         debug {
             minifyEnabled false
             buildConfigField 'boolean', IS_DEVELOPER, 'true'
+            buildConfigField "java.util.Date", "buildTime", "new java.util.Date(" + System.currentTimeMillis() + "L)"
         }
     }
     testOptions {
@@ -40,20 +42,20 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     wearApp project(':wear')
-    compile "com.android.support:appcompat-v7:23.1.1"
-    compile "com.android.support:support-v4:23.1.1"
-    compile "com.android.support:design:23.1.1"
+    compile "com.android.support:appcompat-v7:25.1.1"
+    compile "com.android.support:support-v4:25.1.1"
+    compile "com.android.support:design:25.1.1"
     compile 'com.android.support:multidex:1.0.1'
-    compile 'com.google.code.gson:gson:2.4'
-    compile 'com.google.android.gms:play-services:6.5.87'
-    compile 'com.google.apis:google-api-services-analytics:v3+'
-    compile 'com.crittercism:crittercism-android-agent:5.6.3-rc-1'
-    compile 'javax.jmdns:jmdns:3.4.1'
+    compile 'com.google.code.gson:gson:2.7'
+    compile 'com.google.android.gms:play-services-analytics:10.0.1'
+    compile 'com.google.android.gms:play-services-gcm:10.0.1'
+    compile 'com.crittercism:crittercism-android-agent:5.8.1-rc-1'
+    compile 'org.jmdns:jmdns:3.5.1'
     compile 'com.loopj.android:android-async-http:1.4.9'
     compile 'com.loopj:android-smart-image-view:1.0.0'
-    compile 'com.github.shell-software:fab:1.1.0'
+    compile 'com.github.shell-software:fab:1.1.2'
 
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile 'org.mockito:mockito-core:2.7.6'
     testCompile 'junit:junit:4.12'
-    testCompile 'org.json:json:20140107'
+    testCompile 'org.json:json:20160810'
 }

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -47,8 +47,8 @@ dependencies {
     compile "com.android.support:design:25.1.1"
     compile 'com.android.support:multidex:1.0.1'
     compile 'com.google.code.gson:gson:2.7'
-    compile 'com.google.android.gms:play-services-analytics:10.0.1'
-    compile 'com.google.android.gms:play-services-gcm:10.0.1'
+    compile 'com.google.android.gms:play-services-analytics:10.2.0'
+    compile 'com.google.android.gms:play-services-gcm:10.2.0'
     compile 'com.crittercism:crittercism-android-agent:5.8.1-rc-1'
     compile 'org.jmdns:jmdns:3.5.1'
     compile 'com.loopj.android:android-async-http:1.4.9'

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -42,9 +42,9 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     wearApp project(':wear')
-    compile "com.android.support:appcompat-v7:25.1.1"
-    compile "com.android.support:support-v4:25.1.1"
-    compile "com.android.support:design:25.1.1"
+    compile "com.android.support:appcompat-v7:25.2.0"
+    compile "com.android.support:support-v4:25.2.0"
+    compile "com.android.support:design:25.2.0"
     compile 'com.android.support:multidex:1.0.1'
     compile 'com.google.code.gson:gson:2.7'
     compile 'com.google.android.gms:play-services-analytics:10.2.0'

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -42,13 +42,13 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     wearApp project(':wear')
-    compile "com.android.support:appcompat-v7:25.2.0"
-    compile "com.android.support:support-v4:25.2.0"
-    compile "com.android.support:design:25.2.0"
+    compile "com.android.support:appcompat-v7:25.3.1"
+    compile "com.android.support:support-v4:25.3.1"
+    compile "com.android.support:design:25.3.1"
     compile 'com.android.support:multidex:1.0.1'
     compile 'com.google.code.gson:gson:2.7'
-    compile 'com.google.android.gms:play-services-analytics:10.2.0'
-    compile 'com.google.android.gms:play-services-gcm:10.2.0'
+    compile 'com.google.android.gms:play-services-analytics:10.2.1'
+    compile 'com.google.android.gms:play-services-gcm:10.2.1'
     compile 'com.crittercism:crittercism-android-agent:5.8.1-rc-1'
     compile 'org.jmdns:jmdns:3.5.1'
     compile 'com.loopj.android:android-async-http:1.4.9'

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -2,11 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="org.openhab.habdroid"
     android:versionCode="21"
-    android:versionName="1.8.0.5" >
-    <uses-sdk
-        android:minSdkVersion="15"
-        android:targetSdkVersion="21"
-        />
+    android:versionName="1.8.0.5">
+
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
@@ -17,30 +14,44 @@
     <!-- Keeps the processor from sleeping when a message is received. -->
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
-    <permission android:name="org.openhab.habdroid.gcm.permission.C2D_MESSAGE"
+
+    <permission
+        android:name="org.openhab.habdroid.gcm.permission.C2D_MESSAGE"
         android:protectionLevel="signature" />
+
     <uses-permission android:name="org.openhab.habdroid.gcm.permission.C2D_MESSAGE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
     <uses-feature
         android:name="android.hardware.location.gps"
         android:required="false" />
     <uses-feature
         android:name="android.hardware.nfc"
         android:required="false" />
+
     <application
         android:name=".core.HABDroid"
         android:allowBackup="true"
+        android:fullBackupContent="true"
         android:icon="@drawable/openhabicon"
         android:label="@string/app_name"
+        android:resizeableActivity="true"
+        android:supportsPictureInPicture="false"
         android:theme="@style/HABDroid.Light">
         <activity
             android:name="org.openhab.habdroid.ui.OpenHABPreferencesActivity"
-            android:label="@string/app_preferences_name" >
-        </activity>
+            android:label="@string/app_preferences_name" />
         <activity
             android:name="org.openhab.habdroid.ui.OpenHABMainActivity"
             android:label="@string/app_name"
             android:launchMode="singleTop">
+            <!-- for Nougat -->
+            <layout
+                android:defaultHeight="500dp"
+                android:defaultWidth="600dp"
+                android:gravity="top|end"
+                android:minHeight="320dp"
+                android:minWidth="480dp" />
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -61,13 +72,13 @@
         </activity>
         <activity
             android:name="org.openhab.habdroid.ui.OpenHABWriteTagActivity"
-            android:label="@string/title_activity_openhabwritetag" >
-        </activity>
+            android:label="@string/title_activity_openhabwritetag" />
         <activity android:name="de.duenndns.ssl.MemorizingActivity" />
+
         <service
             android:name=".core.OpenHABVoiceService"
-            android:exported="false">
-        </service>
+            android:exported="false" />
+
         <receiver
             android:name="org.openhab.habdroid.core.GcmBroadcastReceiver"
             android:permission="com.google.android.c2dm.permission.SEND">
@@ -82,8 +93,10 @@
                 <category android:name="org.openhab.habdroid" />
             </intent-filter>
         </receiver>
+
         <service android:name="org.openhab.habdroid.core.GcmIntentService" />
-        <receiver android:name=".ui.VoiceWidget"
+        <receiver
+            android:name=".ui.VoiceWidget"
             android:label="@string/title_voice_widget">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
@@ -92,8 +105,8 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/voice_widget_info" />
         </receiver>
-<!--    This is temp disabled because of a bug in GMS 6.5
-        <meta-data android:name="com.google.android.gms.analytics.globalConfigResource"
-            android:resource="@xml/global_tracker" /> -->
+        <!--    This is temp disabled because of a bug in GMS 6.5
+                <meta-data android:name="com.google.android.gms.analytics.globalConfigResource"
+                    android:resource="@xml/global_tracker" /> -->
     </application>
 </manifest>

--- a/mobile/src/main/java/de/duenndns/ssl/MemorizingActivity.java
+++ b/mobile/src/main/java/de/duenndns/ssl/MemorizingActivity.java
@@ -24,16 +24,16 @@
 package de.duenndns.ssl;
 
 
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnCancelListener;
 import android.content.DialogInterface.OnClickListener;
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
-public class MemorizingActivity extends Activity
+public class MemorizingActivity extends AppCompatActivity
 		implements OnClickListener,OnCancelListener {
 	final static String TAG = "MemorizingActivity";
 

--- a/mobile/src/main/java/de/duenndns/ssl/MemorizingTrustManager.java
+++ b/mobile/src/main/java/de/duenndns/ssl/MemorizingTrustManager.java
@@ -36,6 +36,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.Uri;
 import android.os.Handler;
+import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
 
 import java.io.File;
@@ -75,7 +76,7 @@ public class MemorizingTrustManager implements X509TrustManager {
     static String KEYSTORE_FILE = "KeyStore.bks";
 
     Context master;
-    Activity foregroundAct;
+    AppCompatActivity foregroundAct;
     NotificationManager notificationManager;
     private static int decisionId = 0;
     private static HashMap<Integer, MTMDecision> openDecisions = new HashMap<Integer, MTMDecision>();
@@ -155,7 +156,7 @@ public class MemorizingTrustManager implements X509TrustManager {
      *
      * @param act Activity to be bound
      */
-    public void bindDisplayActivity(Activity act) {
+    public void bindDisplayActivity(AppCompatActivity act) {
         foregroundAct = act;
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/core/NetworkConnectivityInfo.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/NetworkConnectivityInfo.java
@@ -52,7 +52,7 @@ public class NetworkConnectivityInfo implements Parcelable {
             connectivityInfo.setNetworkType(activeNetworkInfo.getType());
             if (activeNetworkInfo.getType() == ConnectivityManager.TYPE_WIFI) {
                 // get ssid here
-                WifiManager wifiManager = (WifiManager) ctx.getSystemService(Context.WIFI_SERVICE);
+                WifiManager wifiManager = (WifiManager) ctx.getApplicationContext().getSystemService(Context.WIFI_SERVICE);
                 WifiInfo wifiConnectionInfo = wifiManager.getConnectionInfo();
                 if (wifiConnectionInfo != null) {
                     connectivityInfo.setSsid(wifiConnectionInfo.getSSID());

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
@@ -22,10 +22,13 @@ import android.preference.PreferenceActivity;
 import android.security.KeyChain;
 import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
+import android.security.keystore.KeyProperties;
 import android.util.Log;
+import java.text.DateFormat;
 
 import com.google.android.gms.analytics.GoogleAnalytics;
 
+import org.openhab.habdroid.BuildConfig;
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.util.Constants;
 import org.openhab.habdroid.util.Util;
@@ -33,6 +36,9 @@ import org.openhab.habdroid.util.Util;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.security.cert.X509Certificate;
+import java.util.Locale;
+
+import static android.R.attr.format;
 
 /**
  * This is a class to provide preferences activity for application.
@@ -109,6 +115,8 @@ public class OpenHABPreferencesActivity extends PreferenceActivity {
         });
         updatePasswordPreferenceSummary(passwordPreference, null);
         updateTextPreferenceSummary(versionPreference, null);
+        versionPreference.setSummary(versionPreference.getSummary() + " - " +
+                DateFormat.getDateTimeInstance().format(BuildConfig.buildTime));
 
 
         updateSslCleintCertSumary(sslClientCert);
@@ -130,12 +138,21 @@ public class OpenHABPreferencesActivity extends PreferenceActivity {
 
                 sslClientCert.getSharedPreferences().edit().putString(sslClientCert.getKey(), null).apply();
 
-                KeyChain.choosePrivateKeyAlias(OpenHABPreferencesActivity.this,
-                        keyChainAliasCallback,
-                        new String[]{"RSA", "DSA"},
-                        null,
-                        getPreferenceString(altUrlPreference, null),
-                        -1, null);
+                if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+                    KeyChain.choosePrivateKeyAlias(OpenHABPreferencesActivity.this,
+                            keyChainAliasCallback,
+                            new String[]{"RSA", "DSA"},
+                            null,
+                            getPreferenceString(altUrlPreference, null),
+                            -1, null);
+                } else {
+                    KeyChain.choosePrivateKeyAlias(OpenHABPreferencesActivity.this,
+                            keyChainAliasCallback,
+                            new String[]{KeyProperties.KEY_ALGORITHM_RSA, KeyProperties.KEY_ALGORITHM_EC},
+                            null,
+                            Uri.parse(getPreferenceString(altUrlPreference, null)),
+                            null);
+                }
 
                 return true;
             }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetAdapter.java
@@ -11,6 +11,7 @@ package org.openhab.habdroid.ui;
 
 import android.content.Context;
 import android.net.Uri;
+import android.os.Build;
 import android.support.v7.widget.SwitchCompat;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -40,8 +41,6 @@ import android.widget.VideoView;
 import com.loopj.android.http.AsyncHttpClient;
 import com.loopj.android.http.TextHttpResponseHandler;
 
-import cz.msebera.android.httpclient.Header;
-import cz.msebera.android.httpclient.entity.StringEntity;
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.model.OpenHABItem;
 import org.openhab.habdroid.model.OpenHABWidget;
@@ -59,6 +58,9 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
+
+import cz.msebera.android.httpclient.Header;
+import cz.msebera.android.httpclient.entity.StringEntity;
 
 /**
  * This class provides openHAB widgets adapter for list view.
@@ -845,8 +847,12 @@ public class OpenHABWidgetAdapter extends ArrayAdapter<OpenHABWidget> {
             if (sliderItem != null)
                 sendItemCommand(sliderItem, String.valueOf(seekBar.getProgress()));
         } else if (volumeDownWidget instanceof Button) {
-            volumeDownWidget.callOnClick();
-        } else {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+				volumeDownWidget.callOnClick();
+			} else {
+				volumeDownWidget.performClick();
+			}
+		} else {
             return false;
         }
         return true;
@@ -860,8 +866,12 @@ public class OpenHABWidgetAdapter extends ArrayAdapter<OpenHABWidget> {
             if (sliderItem != null)
                 sendItemCommand(sliderItem, String.valueOf(seekBar.getProgress()));
         } else if (volumeUpWidget instanceof Button) {
-            volumeUpWidget.callOnClick();
-        } else {
+			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1) {
+				volumeUpWidget.callOnClick();
+			} else {
+				volumeUpWidget.performClick();
+			}
+		} else {
             return false;
         }
         return true;

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWriteTagActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWriteTagActivity.java
@@ -9,7 +9,6 @@
 
 package org.openhab.habdroid.ui;
 
-import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.Intent;
 import android.nfc.FormatException;
@@ -20,6 +19,7 @@ import android.nfc.Tag;
 import android.nfc.tech.Ndef;
 import android.nfc.tech.NdefFormatable;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Menu;
@@ -36,7 +36,7 @@ import java.net.URISyntaxException;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public class OpenHABWriteTagActivity extends Activity {
+public class OpenHABWriteTagActivity extends AppCompatActivity {
 
 	// Logging TAG
 	private static final String TAG = OpenHABWriteTagActivity.class.getSimpleName();

--- a/mobile/src/main/java/org/openhab/habdroid/ui/widget/SegmentedControlButton.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/widget/SegmentedControlButton.java
@@ -32,7 +32,7 @@ import android.widget.RadioButton;
 import org.openhab.habdroid.R;
 
 /** @author benjamin ferrari */
-public class SegmentedControlButton extends RadioButton {
+public class SegmentedControlButton extends android.support.v7.widget.AppCompatRadioButton {
 
     private Drawable backgroundSelected;
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.java
@@ -62,7 +62,7 @@ public class AsyncServiceResolver extends Thread implements ServiceListener {
     public void run() {
         WifiManager wifi =
                    (android.net.wifi.WifiManager)
-                      mCtx.getSystemService(android.content.Context.WIFI_SERVICE);
+                      mCtx.getApplicationContext().getSystemService(android.content.Context.WIFI_SERVICE);
         mMulticastLock = wifi.createMulticastLock("HABDroidMulticastLock");
         mMulticastLock.setReferenceCounted(true);
         try {

--- a/mobile/src/main/res/layout/openhabinfo.xml
+++ b/mobile/src/main/res/layout/openhabinfo.xml
@@ -3,7 +3,7 @@
               android:orientation="vertical"
               android:layout_width="fill_parent"
               android:layout_height="fill_parent"
-              tools:context=".OpenHABWriteTagActivity" >
+              tools:context="org.openhab.habdroid.ui.OpenHABWriteTagActivity" >
     <TextView
         android:id="@+id/openhab_version_label"
         android:layout_width="fill_parent"

--- a/mobile/src/main/res/layout/openhabwritetag.xml
+++ b/mobile/src/main/res/layout/openhabwritetag.xml
@@ -3,7 +3,7 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".OpenHABWriteTagActivity"
+    tools:context="org.openhab.habdroid.ui.OpenHABWriteTagActivity"
     android:layout_gravity="center"
     >
     <ImageView

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="app_discoveryinbox_delete">Delete</string>
     <string name="app_discoveryinbox_nothings">No new things</string>
     <string name="app_discovery">Activate Discovery</string>
+    <string name="empty_string">\?</string>
     <!-- Main menu items -->
     <string name="mainmenu_openhab_preferences">Settings</string>
     <string name="mainmenu_openhab_selectsitemap">Select default sitemap</string>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -8,51 +8,45 @@
             android:summary="@string/settings_openhab_demomode_summary"
             android:title="@string/settings_openhab_demomode" />
         <EditTextPreference
-            android:defaultValue=""
+            android:defaultValue="@string/empty_string"
             android:dependency="default_openhab_demomode"
+            android:inputType="textNoSuggestions"
             android:key="default_openhab_url"
             android:summary="@string/settings_openhab_url_summary"
-            android:title="@string/settings_openhab_url"
-            android:inputType="textNoSuggestions"
-            />
+            android:title="@string/settings_openhab_url" />
         <EditTextPreference
-            android:defaultValue=""
+            android:defaultValue="@string/empty_string"
             android:dependency="default_openhab_demomode"
+            android:inputType="textNoSuggestions"
             android:key="default_openhab_alturl"
             android:summary="@string/settings_openhab_alturl_summary"
-            android:title="@string/settings_openhab_alturl"
-            android:inputType="textNoSuggestions"
-            />
+            android:title="@string/settings_openhab_alturl" />
         <EditTextPreference
-            android:defaultValue=""
+            android:defaultValue="@string/empty_string"
             android:dependency="default_openhab_demomode"
+            android:inputType="textNoSuggestions"
             android:key="default_openhab_username"
             android:summary="@string/settings_openhab_username_summary"
-            android:title="@string/settings_openhab_username"
-            android:inputType="textNoSuggestions"
-            />
+            android:title="@string/settings_openhab_username" />
         <EditTextPreference
-            android:defaultValue=""
+            android:defaultValue="@string/empty_string"
             android:dependency="default_openhab_demomode"
             android:inputType="textPassword"
             android:key="default_openhab_password"
             android:summary="@string/settings_openhab_password_summary"
-            android:title="@string/settings_openhab_password"
-            />
+            android:title="@string/settings_openhab_password" />
         <Preference
-                android:defaultValue="@string/settings_openhab_none"
-                android:dependency="default_openhab_demomode"
-                android:clickable="true"
-                android:key="default_openhab_sslclientcert"
-                android:summary=""
-                android:title="@string/settings_openhab_sslclientcert"
-            />
+            android:clickable="true"
+            android:defaultValue="@string/settings_openhab_none"
+            android:dependency="default_openhab_demomode"
+            android:key="default_openhab_sslclientcert"
+            android:summary=""
+            android:title="@string/settings_openhab_sslclientcert" />
         <Preference
-                android:dependency="default_openhab_demomode"
-                android:clickable="true"
-                android:key="default_openhab_sslclientcert_howto"
-                android:title="@string/settings_openhab_sslclientcert_howto"
-        />
+            android:clickable="true"
+            android:dependency="default_openhab_demomode"
+            android:key="default_openhab_sslclientcert_howto"
+            android:title="@string/settings_openhab_sslclientcert_howto" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="default_openhab_sslcert"
@@ -66,11 +60,11 @@
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_display_title">
         <ListPreference
-            android:key="default_openhab_theme"
-            android:title="@string/settings_openhab_theme"
-            android:defaultValue="dark"
+            android:defaultValue="@string/theme_name_dark"
             android:entries="@array/themeArray"
-            android:entryValues="@array/themeValues" />
+            android:entryValues="@array/themeValues"
+            android:key="default_openhab_theme"
+            android:title="@string/settings_openhab_theme" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="default_openhab_screentimeroff"

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -22,5 +22,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.gms:play-services-wearable:10.0.1'
+    compile 'com.google.android.gms:play-services-wearable:10.2.0'
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 25
+    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "org.openhab.habdroid"
         minSdkVersion 20
-        targetSdkVersion 21
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
     }
@@ -22,6 +22,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.support:wearable:1.3.+'
-    compile 'com.google.android.gms:play-services-wearable:5.0.77'
+    compile 'com.google.android.gms:play-services-wearable:10.0.1'
 }

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -22,5 +22,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.gms:play-services-wearable:10.2.0'
+    compile 'com.google.android.gms:play-services-wearable:10.2.1'
 }


### PR DESCRIPTION
WHAT THIS DOES:

* Runs in API 14+
* Targets API 25, buildtools 25.0.2
* Uses latest gradle & updated libraries
* Includes multiwindows support for Chromebook/Nougat
* Adds build timestamp to app info in settings
* Use AppCompatActivity everywhere
* Minor lint warning fixes (there are many more unaddressed)

PULL-REQUEST NOTES:

* DSA is not supported by Google after API 23.  Use EC instead I guess (see the [commit](https://github.com/fat-tire/openhab.android/commit/b19240f4cd359e24ab34dfefb9afe8a3d3ea666d#diff-b8963974f554d6698e36b7b2a0fa790aR151) for how this was handled).
* Has only been tested on API 14 emulator but seems to run fine.
* Do not manually request fine location or other permissionw w/new runtime permissions system.
  I can't find where it is invoked and would rather do it in-context.
  Was this permission requested for future use perhaps?
* For fun (and to help me make sure I was running the latest) I added a timestamp to the last settings item.
* Please test and look for any issues
* If nothing else, this should save someone some time in updating the build.

That's it!  Enjoy!