### PR TITLE
More consistent strings

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABTracker.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABTracker.java
@@ -108,7 +108,7 @@ public class OpenHABTracker implements AsyncServiceResolverListener {
                     if (mOpenHABUrl.length() > 0) {
                         // Check if configured local URL is reachable
                         if (checkUrlReachability(mOpenHABUrl)) {
-                            Log.d(TAG, "Connecting to directly configured URL = " + mOpenHABUrl);
+                            Log.d(TAG, "Connecting to local URL = " + mOpenHABUrl);
                             openHABTracked(mOpenHABUrl, mCtx.getString(R.string.info_conn_url));
                             return;
                             // If local URL is not reachable go with remote URL

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -56,7 +56,7 @@
     <string name="info_voice_input">"openHAB, at your command!"</string>
     <string name="info_voice_recognized_text">"Recognized command: %1$s"</string>
     <string name="info_demo_mode">HABDroid is running in demo mode. To connect to your openHAB please go to settings menu.</string>
-    <string name="info_conn_url">Connecting to configured URL</string>
+    <string name="info_conn_url">Connecting to local URL</string>
     <string name="info_conn_rem_url">Connecting to remote URL</string>
     <string name="info_discovery">Discovering openHAB. Please wait...</string>
     <string name="error_no_url">Please check that openHAB is running or configure openHAB URL or remote URL</string>


### PR DESCRIPTION
The String is used as a "oposite" of connecting to a remote url, so it should be changed to "local". This already happend in at least the German and Spannish translation.