### PR TITLE
Make a few strings non-translatable

### DIFF
--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -33,7 +33,6 @@
     <string name="settings_openhab_password_summary">openHAB Passwort</string>
     <string name="settings_openhab_sslclientcert">SSL Client Zertifikat</string>
     <string name="settings_openhab_sslclientcert_howto">SSL Client Zertifikat How-To</string>
-    <string name="settings_openhab_sslclientcert_howto_url">https://github.com/openhab/openhab.android/blob/master/KeyAuth.md</string>
     <string name="settings_openhab_screentimeroff">Deaktiviere Ruhezustand</string>
     <string name="settings_openhab_screentimeroff_summary">Schaltet das automatische Aktivieren des Ruhezustands nach Inaktivität ab, wenn HABDroid läuft.</string>
     <string name="settings_openhab_demomode">Demo Modus</string>
@@ -48,7 +47,7 @@
     <string name="settings_openhab_fullscreen_summary">Blendet die Statusleiste aus</string>
     <string name="settings_ringtone">Klingelton</string>
     <!-- App messages strings -->
-    <string name="title_voice_widget">OpenHAB Sprachbefehl</string>
+    <string name="title_voice_widget">openHAB Sprachbefehl</string>
     <string name="info_voice_input">"openHAB, zu Ihren Diensten!"</string>
     <string name="info_voice_recognized_text">"Erkannter Befehl: %1$s"</string>
     <string name="info_demo_mode">HABDroid läuft im Demo Modus. Unter Einstellungen kann eine eigene openHAB-Instanz konfiguriert werden.</string>

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -2,9 +2,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     >
     <!-- General app strings -->
-    <string name="app_name">openHAB</string>
-    <string name="openhab_service_type">_openhab-server-ssl._tcp.local.</string>
-    <string name="openhab_demo_url">http://demo.openhab.org:8080/</string>
     <string name="app_preferences_name">Einstellungen</string>
     <string name="app_notifications">Benachrichtigungen</string>
     <string name="app_bindings">Bindings</string>
@@ -102,7 +99,7 @@
     <!-- nfc toggle -->
     <string name="nfc_action_on">An</string>
     <string name="nfc_action_off">Aus</string>
-	<string name="nfc_action_toggle">Umschalten</string>
+    <string name="nfc_action_toggle">Umschalten</string>
 
     <!-- drawer -->
     <string name="drawer_open">Sitemap-Bereich öffnen</string>

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    >
     <!-- General app strings -->
     <string name="app_preferences_name">Einstellungen</string>
     <string name="app_notifications">Benachrichtigungen</string>

--- a/mobile/src/main/res/values-es/strings.xml
+++ b/mobile/src/main/res/values-es/strings.xml
@@ -45,7 +45,7 @@
     <string name="settings_openhab_fullscreen_summary">Mostrar a pantalla completa</string>
     <string name="settings_ringtone">Sonido</string>
     <!-- App messages strings -->
-    <string name="title_voice_widget">Comandos de voz OpenHAB</string>
+    <string name="title_voice_widget">Comandos de voz openHAB</string>
     <string name="info_voice_input">"openHAB, ¡a tus órdenes!"</string>
     <string name="info_voice_recognized_text">"Comando reconocido: %1$s"</string>
     <string name="info_demo_mode">HABDroid se ejecuta en modo demo. Por favor, ir al menú configuración para conectarlo a openHAB.</string>

--- a/mobile/src/main/res/values-es/strings.xml
+++ b/mobile/src/main/res/values-es/strings.xml
@@ -2,9 +2,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     >
     <!-- General app strings -->
-    <string name="app_name">openHAB</string>
-    <string name="openhab_service_type">_openhab-server-ssl._tcp.local.</string>
-    <string name="openhab_demo_url">http://demo.openhab.org:8080/</string>
     <string name="app_preferences_name">Configuración</string>
     <string name="app_notifications">Notificaciones</string>
     <string name="app_bindings">Bindings</string>

--- a/mobile/src/main/res/values-es/strings.xml
+++ b/mobile/src/main/res/values-es/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    >
     <!-- General app strings -->
     <string name="app_preferences_name">Configuración</string>
     <string name="app_notifications">Notificaciones</string>

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -42,10 +42,10 @@
     <string name="settings_openhab_sslhost">Ignorer le domaine SSL</string>
     <string name="settings_openhab_sslhost_summary">Ne vérifie pas la pertinence du nom de domaine lors de la connexion</string>
     <string name="settings_openhab_fullscreen">Plein écran</string>
-    <string name="settings_openhab_fullscreen_summary">Afficher OpenHab en mode plein écran</string>
+    <string name="settings_openhab_fullscreen_summary">Afficher openHAB en mode plein écran</string>
     <string name="settings_ringtone">Sonnerie</string>
     <!-- App messages strings -->
-    <string name="title_voice_widget">Commandes vocales OpenHAB</string>
+    <string name="title_voice_widget">Commandes vocales openHAB</string>
     <string name="info_voice_input">openHAB, à vos ordres!"</string>
     <string name="info_voice_recognized_text">"Commande identifiée: %1$s"</string>
     <string name="info_demo_mode">HABDroid fonctionne en mode démo. Pour connecter votre instance openHAB, rendez-vous dans les paramètres de l\'application</string>

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <!-- General app strings -->
-    <string name="app_name">openHAB</string>
-    <string name="openhab_service_type">_openhab-server-ssl._tcp.local.</string>
-    <string name="openhab_demo_url">http://demo.openhab.org:8080/</string>
     <string name="app_preferences_name">Paramètres</string>
     <string name="app_notifications">Notifications</string>
     <string name="app_bindings">Objets et protocoles</string>

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -2,9 +2,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     >
     <!-- General app strings -->
-    <string name="app_name">openHAB</string>
-    <string name="openhab_service_type">_openhab-server-ssl._tcp.local.</string>
-    <string name="openhab_demo_url">http://demo.openhab.org:8080/</string>
     <string name="app_preferences_name">設定</string>
     <string name="app_notifications">通知</string>
     <string name="app_bindings">バインド</string>

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    >
     <!-- General app strings -->
     <string name="app_preferences_name">設定</string>
     <string name="app_notifications">通知</string>

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -33,7 +33,6 @@
     <string name="settings_openhab_password_summary">openHAB パスワード</string>
     <string name="settings_openhab_sslclientcert">SSL クライアント証明書</string>
     <string name="settings_openhab_sslclientcert_howto">SSL クライアント証明書 how-to</string>
-    <string name="settings_openhab_sslclientcert_howto_url">https://github.com/openhab/openhab.android/blob/master/KeyAuth.md</string>
     <string name="settings_openhab_screentimeroff">ディスプレイタイマーを無効にする</string>
     <string name="settings_openhab_screentimeroff_summary">HABDroid が実行中のとき、ディスプレイがスイッチオフになるのを無効にします</string>
     <string name="settings_openhab_demomode">デモモード</string>
@@ -48,7 +47,7 @@
     <string name="settings_openhab_fullscreen_summary">全画面モードで表示します</string>
     <string name="settings_ringtone">着信音</string>
     <!-- App messages strings -->
-    <string name="title_voice_widget">OpenHAB 音声コマンド</string>
+    <string name="title_voice_widget">openHAB 音声コマンド</string>
     <string name="info_voice_input">"openHAB, お話ください!"</string>
     <string name="info_voice_recognized_text">"認識したコマンド: %1$s"</string>
     <string name="info_demo_mode">HABDroid はデモモードで実行中です。 お使いの openHAB に接続するには、設定メニューに移動してください。</string>

--- a/mobile/src/main/res/values-lt/strings.xml
+++ b/mobile/src/main/res/values-lt/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    >
     <!-- General app strings -->
     <string name="app_preferences_name">Nustatymai</string>
     <string name="app_notifications">Pranešimai</string>

--- a/mobile/src/main/res/values-lt/strings.xml
+++ b/mobile/src/main/res/values-lt/strings.xml
@@ -33,7 +33,6 @@
     <string name="settings_openhab_password_summary">openHAB slaptažodis</string>
     <string name="settings_openhab_sslclientcert">Kliento SSL sertifikatas</string>
     <string name="settings_openhab_sslclientcert_howto">Kaip naudoti kliento SSL sertifikatą</string>
-    <string name="settings_openhab_sslclientcert_howto_url">https://github.com/openhab/openhab.android/blob/master/KeyAuth.md</string>
     <string name="settings_openhab_screentimeroff">Neleisti išjungti ekrano</string>
     <string name="settings_openhab_screentimeroff_summary">Neleisti išjungti ekrano, kol paleistas HABDroid</string>
     <string name="settings_openhab_demomode">Demonstracinis režimas</string>
@@ -48,7 +47,7 @@
     <string name="settings_openhab_fullscreen_summary">Rodyti pilno ekrano režimu</string>
     <string name="settings_ringtone">Skambėjimo melodija</string>
     <!-- App messages strings -->
-    <string name="title_voice_widget">OpenHAB balso komandos</string>
+    <string name="title_voice_widget">openHAB balso komandos</string>
     <string name="info_voice_input">\"openHAB, jūsų paliepimu!\"</string>
     <string name="info_voice_recognized_text">\"Neatpažinta komanda: %1$s\"</string>
     <string name="info_demo_mode">HABDroid veikia demonstraciniu režimu. Norėdami prisijungti prie savo openHAB, eikite į nustatymų meniu.</string>

--- a/mobile/src/main/res/values-lt/strings.xml
+++ b/mobile/src/main/res/values-lt/strings.xml
@@ -2,9 +2,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     >
     <!-- General app strings -->
-    <string name="app_name">openHAB</string>
-    <string name="openhab_service_type">_openhab-server-ssl._tcp.local.</string>
-    <string name="openhab_demo_url">http://demo.openhab.org:8080/</string>
     <string name="app_preferences_name">Nustatymai</string>
     <string name="app_notifications">Pranešimai</string>
     <string name="app_bindings">Bindings</string>

--- a/mobile/src/main/res/values-nl/strings.xml
+++ b/mobile/src/main/res/values-nl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    >
     <!-- General app strings -->
     <string name="app_preferences_name">Instellingen</string>
     <string name="app_notifications">Notificaties</string>

--- a/mobile/src/main/res/values-nl/strings.xml
+++ b/mobile/src/main/res/values-nl/strings.xml
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<resources
-    xmlns:tools="http://schemas.android.com/tools"
-    tools:ignore="MissingTranslation">
+<resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     >
     <!-- General app strings -->
-    <string name="app_name">openHAB</string>
-    <string name="openhab_service_type">_openhab-server-ssl._tcp.local.</string>
-    <string name="openhab_demo_url">http://demo.openhab.org:8080/</string>
     <string name="app_preferences_name">Instellingen</string>
     <string name="app_notifications">Notificaties</string>
     <string name="app_bindings">Bindings</string>

--- a/mobile/src/main/res/values-nl/strings.xml
+++ b/mobile/src/main/res/values-nl/strings.xml
@@ -45,7 +45,7 @@
     <string name="settings_openhab_fullscreen_summary">Gebruik volledige scherm</string>
     <string name="settings_ringtone">Beltoon</string>
     <!-- App messages strings -->
-    <string name="title_voice_widget">OpenHAB stem commando\'s</string>
+    <string name="title_voice_widget">openHAB stem commando\'s</string>
     <string name="info_voice_input">"openHAB, at your command!"</string>
     <string name="info_voice_recognized_text">"Herkend commando: %1$s"</string>
     <string name="info_demo_mode">HABDroid draait in demo mode. Gebruik het instellingenmenu om naar je eigen systeem te verbinden</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -36,7 +36,7 @@
     <string name="settings_openhab_password_summary">openHAB password</string>
     <string name="settings_openhab_sslclientcert">SSL client certificate</string>
     <string name="settings_openhab_sslclientcert_howto">SSL client certificate how-to</string>
-    <string name="settings_openhab_sslclientcert_howto_url">https://github.com/openhab/openhab.android/blob/master/KeyAuth.md</string>
+    <string name="settings_openhab_sslclientcert_howto_url" translatable="false">https://github.com/openhab/openhab.android/blob/master/KeyAuth.md</string>
     <string name="settings_openhab_screentimeroff">Disable display timer</string>
     <string name="settings_openhab_screentimeroff_summary">Disable display switch off timer when HABDroid is running</string>
     <string name="settings_openhab_demomode">Demo mode</string>
@@ -51,7 +51,7 @@
     <string name="settings_openhab_fullscreen_summary">Display in fullscreen mode</string>
     <string name="settings_ringtone">Ring tone</string>
     <!-- App messages strings -->
-    <string name="title_voice_widget">OpenHAB Voice Commands</string>
+    <string name="title_voice_widget">openHAB Voice Commands</string>
     <string name="info_voice_input">"openHAB, at your command!"</string>
     <string name="info_voice_recognized_text">"Recognized command: %1$s"</string>
     <string name="info_demo_mode">HABDroid is running in demo mode. To connect to your openHAB please go to settings menu.</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -2,9 +2,9 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     >
     <!-- General app strings -->
-    <string name="app_name">openHAB</string>
-    <string name="openhab_service_type">_openhab-server-ssl._tcp.local.</string>
-    <string name="openhab_demo_url">http://demo.openhab.org:8080/</string>
+    <string name="app_name" translatable="false">openHAB</string>
+    <string name="openhab_service_type" translatable="false">_openhab-server-ssl._tcp.local.</string>
+    <string name="openhab_demo_url" translatable="false">http://demo.openhab.org:8080/</string>
     <string name="app_preferences_name">Settings</string>
     <string name="app_notifications">Notifications</string>
     <string name="app_bindings">Bindings</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
-    >
     <!-- General app strings -->
     <string name="app_name" translatable="false">openHAB</string>
     <string name="openhab_service_type" translatable="false">_openhab-server-ssl._tcp.local.</string>


### PR DESCRIPTION
app_name, openhab_service_type, openhab_demo_url should always be the same.

There seems to be unnecessary ">" in the xml files. Do they have any meaning?