### PR TITLE
remove messages at startup, fix #258

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABTracker.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABTracker.java
@@ -95,7 +95,7 @@ public class OpenHABTracker implements AsyncServiceResolverListener {
                     // If remote URL is configured
                     if (mOpenHABUrl.length() > 0) {
                         Log.d(TAG, "Connecting to remote URL " + mOpenHABUrl);
-                        openHABTracked(mOpenHABUrl, mCtx.getString(R.string.info_conn_rem_url));
+                        openHABTracked(mOpenHABUrl, null);
                     } else {
                         openHABError(mCtx.getString(R.string.error_no_url));
                     }
@@ -108,8 +108,8 @@ public class OpenHABTracker implements AsyncServiceResolverListener {
                     if (mOpenHABUrl.length() > 0) {
                         // Check if configured local URL is reachable
                         if (checkUrlReachability(mOpenHABUrl)) {
-                            Log.d(TAG, "Connecting to directly configured URL = " + mOpenHABUrl);
-                            openHABTracked(mOpenHABUrl, mCtx.getString(R.string.info_conn_url));
+                            Log.d(TAG, "Connecting to local URL = " + mOpenHABUrl);
+                            openHABTracked(mOpenHABUrl, null);
                             return;
                             // If local URL is not reachable go with remote URL
                         } else {
@@ -117,7 +117,7 @@ public class OpenHABTracker implements AsyncServiceResolverListener {
                             // If remote URL is configured
                             if (mOpenHABUrl.length() > 0) {
                                 Log.d(TAG, "Connecting to remote URL " + mOpenHABUrl);
-                                openHABTracked(mOpenHABUrl, mCtx.getString(R.string.info_conn_rem_url));
+                                openHABTracked(mOpenHABUrl, null);
                             } else {
                                 openHABError(mCtx.getString(R.string.error_no_url));
                             }
@@ -167,7 +167,7 @@ public class OpenHABTracker implements AsyncServiceResolverListener {
         // If remote URL is configured
         if (mOpenHABUrl.length() > 0) {
             Log.d(TAG, "Connecting to remote URL " + mOpenHABUrl);
-            openHABTracked(mOpenHABUrl, mCtx.getString(R.string.info_conn_rem_url));
+            openHABTracked(mOpenHABUrl, null);
         } else {
             openHABError(mCtx.getString(R.string.error_no_url));
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -1127,12 +1127,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         PackageManager pm = getPackageManager();
         List<ResolveInfo> activities = pm.queryIntentActivities(new Intent(
                 RecognizerIntent.ACTION_RECOGNIZE_SPEECH), 0);
-        if (activities.size() == 0) {
-//            speakButton.setEnabled(false);
-//            speakButton.setText("Voice recognizer not present");
-            Toast.makeText(this, "Voice recognizer not present, voice recognition disabled",
-                    Toast.LENGTH_SHORT).show();
-        } else {
+        if (activities.size() != 0) {
             mVoiceRecognitionEnabled = true;
         }
     }


### PR DESCRIPTION
IMO these messages are not needed:
1. When I am on WIFI and see my sitemap, it connected most likely direct and when I am not on WIFI and I see my sitemap, it connected via Cloud Companion. It still logs the messages and gives and error when connection failed.
2. If the voice recognizer is not available the microphone icon is not present