### PR TITLE
Implement dynamic GCM sender ID

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/NotificationDeletedBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/NotificationDeletedBroadcastReceiver.java
@@ -37,6 +37,9 @@ public class NotificationDeletedBroadcastReceiver extends BroadcastReceiver {
             sendBundle.putString("notificationId", String.valueOf(intent.getExtras().getInt("notificationId")));
             new AsyncTask<Void, Void, Void>() {
                 protected Void doInBackground(Void... params) {
+                    if (OpenHABMainActivity.GCM_SENDER_ID == null)
+                        return null;
+
                     try {
                         gcm.send(OpenHABMainActivity.GCM_SENDER_ID + "@gcm.googleapis.com",
                                 "1", sendBundle);

--- a/mobile/src/main/java/org/openhab/habdroid/core/notifications/GoogleCloudMessageConnector.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/notifications/GoogleCloudMessageConnector.java
@@ -1,0 +1,90 @@
+package org.openhab.habdroid.core.notifications;
+
+import android.content.Context;
+import android.os.Build;
+import android.provider.Settings;
+import android.util.Log;
+
+import com.google.android.gms.gcm.GoogleCloudMessaging;
+import com.loopj.android.http.AsyncHttpResponseHandler;
+import com.loopj.android.http.TextHttpResponseHandler;
+
+import org.openhab.habdroid.util.Constants;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+
+import cz.msebera.android.httpclient.Header;
+
+public class GoogleCloudMessageConnector {
+    private static final String TAG = GoogleCloudMessageConnector.class.getSimpleName();
+
+    private NotificationSettings mSettings;
+    private String mDeviceId;
+    private GoogleCloudMessaging mGcm;
+    private boolean isRegistered;
+
+    public GoogleCloudMessageConnector(NotificationSettings settings, String deviceId, GoogleCloudMessaging gcm) {
+        this.mSettings = settings;
+        this.mDeviceId = deviceId;
+        this.mGcm = gcm;
+    }
+
+    /**
+     * Registers the android device in GCM and in openHAB-cloud with the device ID and the sender
+     * ID returned from {@link NotificationSettings#getSenderId()}.
+     *
+     * @return True, if the registration succeeded, false otherwise.
+     */
+    public boolean register() {
+        String senderId = mSettings.getSenderId();
+        if (senderId == null)
+            return false;
+
+        String registrationId;
+        try {
+            registrationId = mGcm.register(senderId);
+        } catch (IOException e) {
+            Log.e(TAG, "Error getting GCM ID: " + e.getMessage(), e);
+            return false;
+        }
+
+        String deviceModel = null;
+        try {
+            deviceModel = URLEncoder.encode(Build.MODEL, "UTF-8");
+        } catch (UnsupportedEncodingException ex) {
+            Log.d(TAG, "Could not encode device model: " + ex.getMessage());
+            return false;
+        }
+        String regUrl;
+
+        try {
+            regUrl = mSettings.getOpenHABCloudURL().toURI().resolve("/addAndroidRegistration?deviceId=" + mDeviceId +
+                    "&deviceModel=" + deviceModel + "&regId=" + registrationId).toString();
+        } catch (URISyntaxException ex) {
+            Log.d(TAG, "Could not resolve registration path to openHAB URI: " + ex.getMessage());
+            return false;
+        }
+
+        Log.d(TAG, "Register device at openHAB-cloud with URL: " + regUrl);
+        mSettings.getHttpClient().get(regUrl, new TextHttpResponseHandler() {
+            @Override
+            public void onFailure(int statusCode, Header[] headers, String responseBody, Throwable error) {
+                Log.e(TAG, "GCM reg id error: " + error.getMessage());
+                isRegistered = false;
+                if (responseBody != null)
+                    Log.e(TAG, "Error response = " + responseBody);
+            }
+
+            @Override
+            public void onSuccess(int statusCode, Header[] headers, String responseBody) {
+                Log.d(TAG, "GCM reg id success");
+                isRegistered = true;
+            }
+        });
+
+        return isRegistered;
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/core/notifications/NotificationSettings.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/notifications/NotificationSettings.java
@@ -1,0 +1,126 @@
+package org.openhab.habdroid.core.notifications;
+
+import android.util.Log;
+
+import com.loopj.android.http.SyncHttpClient;
+import com.loopj.android.http.TextHttpResponseHandler;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.openhab.habdroid.util.Constants;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import cz.msebera.android.httpclient.Header;
+
+public class NotificationSettings {
+    private static final String TAG = NotificationSettings.class.getSimpleName();
+
+    private static final String SETTINGS_ROUTE = "/api/v1/settings/notifications";
+    private static final String GCM_OBJECT_KEY = "gcm";
+    private static final String GCM_SENDER_ID_KEY = "senderId";
+
+    private URL openHABCloudURL;
+    private SyncHttpClient httpClient;
+    private JSONObject settings = new JSONObject();
+    private boolean isLoaded = false;
+
+    /**
+     * Constructor
+     *
+     * @param openHABCloudURL
+     * @param httpClient
+     * @throws MalformedURLException
+     */
+    public NotificationSettings(String openHABCloudURL, SyncHttpClient httpClient) throws MalformedURLException {
+        this(new URL(openHABCloudURL), httpClient);
+    }
+
+    /**
+     * Constructor
+     *
+     * @param openHABCloudURL
+     * @param httpClient
+     */
+    public NotificationSettings(URL openHABCloudURL, SyncHttpClient httpClient) {
+        this.openHABCloudURL = openHABCloudURL;
+        this.httpClient = httpClient;
+    }
+
+    SyncHttpClient getHttpClient () {
+        return this.httpClient;
+    }
+
+    private void loadSettings() {
+        if (isLoaded) {
+            Log.d(TAG, "Requested to load notifications settings, but it is loaded already.");
+            return;
+        }
+
+        String requestUrl = null;
+        try {
+            requestUrl = new URL(openHABCloudURL, SETTINGS_ROUTE).toString();
+        } catch (MalformedURLException ex) {
+            Log.d(TAG, "Unable to build request URL, got error: " + ex.getMessage(), ex);
+            return;
+        }
+        Log.d(TAG, "Request notification settings from: " + requestUrl);
+        httpClient.get(requestUrl, new SettingsAsyncHttpResponseHandler());
+    }
+
+    /**
+     * Returns the configured sender ID of the openHBA-cloud instance passed to the constructor. If
+     * no sender ID was configured, null is returned.
+     *
+     * @return
+     */
+    public String getSenderId() {
+        if (!isLoaded) {
+            loadSettings();
+        }
+
+        try {
+            return settings.getString(GCM_SENDER_ID_KEY);
+        } catch(JSONException ex) {
+            Log.d(TAG, "The settings does not contain a senderId, return the default one.");
+            return Constants.DEFAULT_GCM_SENDER_ID;
+        }
+    }
+
+    /**
+     * Returns the URL object which represents the openHAB-cloud instance.
+     *
+     * @return
+     */
+    public URL getOpenHABCloudURL() {
+        return this.openHABCloudURL;
+    }
+
+    private class SettingsAsyncHttpResponseHandler extends TextHttpResponseHandler {
+        @Override
+        public void onFailure(int statusCode, Header[] headers, String responseBody, Throwable error) {
+            Log.e(TAG, "Error loading notification settings: " + error.getMessage());
+        }
+
+        @Override
+        public void onSuccess(int statusCode, Header[] headers, String jsonString) {
+            Log.d(TAG, "Successfully requested notification settings, parsing it now.");
+
+            JSONObject notifySettings;
+            try {
+                notifySettings = new JSONObject(jsonString);
+            } catch (JSONException e) {
+                Log.d(TAG, "Unable to parse returned body as JSON: " + e.getMessage(), e);
+                return;
+            }
+
+            isLoaded = true;
+            try {
+                settings = notifySettings.getJSONObject(GCM_OBJECT_KEY);
+            } catch(JSONException ex) {
+                Log.d(TAG, "Returned notification JSON settings does not contain a GCM key. Error: " + ex.getMessage());
+            }
+        }
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABInfoFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABInfoFragment.java
@@ -39,6 +39,7 @@ public class OpenHABInfoFragment extends DialogFragment {
     private TextView mOpenHABUUIDText;
     private TextView mOpenHABSecretText;
     private TextView mOpenHABSecretLabel;
+    private TextView mOpenHABNotificationText;
     private String mOpenHABBaseUrl;
     private String mUsername;
     private String mPassword;
@@ -55,6 +56,7 @@ public class OpenHABInfoFragment extends DialogFragment {
         mOpenHABSecretText = (TextView)view.findViewById(R.id.openhab_secret);
         mOpenHABSecretLabel = (TextView)view.findViewById(R.id.openhab_secret_label);
         mOpenHABVersionLabel = (TextView)view.findViewById(R.id.openhab_version_label);
+        mOpenHABNotificationText = (TextView)view.findViewById(R.id.openhab_gcm);
         Bundle bundle=getArguments();
 
         if (bundle!=null){
@@ -93,6 +95,7 @@ public class OpenHABInfoFragment extends DialogFragment {
         setVersionText();
         setUuidText();
         setSecretText();
+        setGcmText();
     }
 
     private void setSecretText() {
@@ -179,4 +182,16 @@ public class OpenHABInfoFragment extends DialogFragment {
     }
 
 
+    private void setGcmText() {
+        String infoString;
+        if (OpenHABMainActivity.GCM_SENDER_ID == null) {
+            infoString = getString(R.string.info_openhab_gcm_not_connected);
+        } else {
+            infoString = getString(R.string.info_openhab_gcm_connected);
+        }
+
+        mOpenHABNotificationText.setText(
+                String.format(infoString, OpenHABMainActivity.GCM_SENDER_ID)
+        );
+    }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -1198,6 +1198,10 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
     private void gcmRegisterBackground() {
         Crittercism.setUsername(openHABUsername);
         OpenHABMainActivity.GCM_SENDER_ID = null;
+        // if no notification settings can be constructed, no GCM registration can be made.
+        if (getNotificationSettings() == null)
+            return;
+
         if (mGcm == null)
             mGcm = GoogleCloudMessaging.getInstance(getApplicationContext());
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -26,4 +26,5 @@ public class Constants {
     public static final String PREFERENCE_TONE              = "default_openhab_alertringtone";
     public static final String PREFERENCE_SSLCLIENTCERT     = "default_openhab_sslclientcert";
     public static final String PREFERENCE_SSLCLIENTCERT_HOWTO = "default_openhab_sslclientcert_howto";
+    public static final String DEFAULT_GCM_SENDER_ID        = "737820980945";
 }

--- a/mobile/src/main/java/org/openhab/habdroid/util/MySyncHttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MySyncHttpClient.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2010-2016, openHAB.org and others.
+ *
+ *   All rights reserved. This program and the accompanying materials
+ *   are made available under the terms of the Eclipse Public License v1.0
+ *   which accompanies this distribution, and is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ */
+
+package org.openhab.habdroid.util;
+
+import android.content.Context;
+import android.preference.PreferenceManager;
+
+import com.loopj.android.http.SyncHttpClient;
+
+import javax.net.ssl.SSLContext;
+
+import cz.msebera.android.httpclient.conn.ssl.SSLSocketFactory;
+import de.duenndns.ssl.MemorizingTrustManager;
+
+public class MySyncHttpClient extends SyncHttpClient {
+
+	private SSLContext sslContext;
+	private SSLSocketFactory sslSocketFactory;
+
+	public MySyncHttpClient(Context ctx) {
+        super();
+		try {
+	        sslContext = SSLContext.getInstance("TLS");
+	        sslContext.init(MyKeyManager.getInstance(ctx), MemorizingTrustManager.getInstanceList(ctx), new java.security.SecureRandom());
+	        sslSocketFactory = new MySSLSocketFactory(sslContext);
+            if (PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean(Constants.PREFERENCE_SSLHOST, false))
+                sslSocketFactory.setHostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
+	        this.setSSLSocketFactory(sslSocketFactory);
+	    } catch (Exception ex) {
+	    }
+	}
+}

--- a/mobile/src/main/res/layout/openhabinfo.xml
+++ b/mobile/src/main/res/layout/openhabinfo.xml
@@ -55,4 +55,21 @@
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:layout_marginTop="20dp"
         android:gravity="center" />
+    <TextView
+        android:id="@+id/openhab_gcm_label"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/info_openhab_gcm_label"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:layout_marginTop="20dp"
+        android:gravity="center" />
+    <TextView
+        android:id="@+id/openhab_gcm"
+        android:textIsSelectable="true"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:text=""
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:layout_marginTop="20dp"
+        android:gravity="center" />
 </LinearLayout>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -80,6 +80,9 @@
     <string name="info_openhab_apiversion_label">openHAB Rest API Version</string>
     <string name="info_openhab_uuid_label">openHAB UUID</string>
     <string name="info_openhab_secret_label">openHAB Secret</string>
+    <string name="info_openhab_gcm_label">Google Cloud Message Status</string>
+    <string name="info_openhab_gcm_not_connected">Device registration failed with Sender ID %s</string>
+    <string name="info_openhab_gcm_connected">Registered device with Sender ID %s</string>
     <string name="action_settings">Settings</string>
     <string name="nfc_dialog_title">Please select NFC tag action</string>
     <string name="info_not_set">Not set</string>


### PR DESCRIPTION
Instead of hardcoding the sender ID of myopenhab.com in this otherwise
dynamic app, the sender ID, which is used to register the device to a
specific service account in Google Cloud Messaging, is now queried
dynamically using a new notification settings api endpoint on the
openhab-cloud endpoint.

When a user adds a new openHAB remote URL (in fact, whenever the openHAB
main activity is created), the app will start registering the device in
the used openhab-cloud instance and GCM. After all data checks, the app
will query the /api/v1/settings/notifications endpoint of this
openhab-cloud instance. This endpoint will return a JSONObject with
information about the notification settings to use (currently the GCM
sender ID only).

The returned sender ID will be used to register the android device in GCM
and, if this was successfull, the device will be registered in the
openHAB-cloud instance.

A fallback is implemented: If the sender ID could not be recognized (or is
not configured) in the openHAB-cloud instance, the currently hardcoded one
will be used.

A new information is provided in the openHAB info dialog to make it
possible to the user to check the configured sender ID. It will provide
the used sender ID and the information, if the device could be registered
in openHAB-cloud. The target audience are persons, who use their own
openHAB-cloud instance to check their configuration. The information, if
it is positive, doesn't guarantee, that push notifications will work, but
it gives a good indication if it should work and could be starting point
to find problems, if it doesn't work.

This change more or less depends on the following commit/PR to work:
 https://github.com/openhab/openhab-cloud/pull/89/commits/49d0a49fcee26c6c8bda07ca27a0729e8b79b68c
 https://github.com/openhab/openhab-cloud/pull/89

Signed-off-by: Florian <florian.schmidt.welzow@t-online.de>