### PR TITLE
Do not start discovery service if only remote url is configured

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABTracker.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABTracker.java
@@ -111,20 +111,15 @@ public class OpenHABTracker implements AsyncServiceResolverListener {
                             Log.d(TAG, "Connecting to local URL = " + mOpenHABUrl);
                             openHABTracked(mOpenHABUrl, mCtx.getString(R.string.info_conn_url));
                             return;
-                            // If local URL is not reachable go with remote URL
-                        } else {
-                            mOpenHABUrl = Util.normalizeUrl(settings.getString(Constants.PREFERENCE_ALTURL, ""));
-                            // If remote URL is configured
-                            if (mOpenHABUrl.length() > 0) {
-                                Log.d(TAG, "Connecting to remote URL " + mOpenHABUrl);
-                                openHABTracked(mOpenHABUrl, mCtx.getString(R.string.info_conn_rem_url));
-                            } else {
-                                openHABError(mCtx.getString(R.string.error_no_url));
-                            }
                         }
-                    // If no local URL is configured
+                    }
+                    // If local URL is not reachable or not configured, try with remote URL
+                    mOpenHABUrl = Util.normalizeUrl(settings.getString(Constants.PREFERENCE_ALTURL, ""));
+                    if (mOpenHABUrl.length() > 0) {
+                        Log.d(TAG, "Connecting to remote URL " + mOpenHABUrl);
+                        openHABTracked(mOpenHABUrl, mCtx.getString(R.string.info_conn_rem_url));
                     } else {
-                        // Start service discovery
+                        // if not URL is configured, start service discovery
                         mServiceResolver = new AsyncServiceResolver(mCtx, this, mOpenHABServiceType);
                         bonjourDiscoveryStarted();
                         mServiceResolver.start();


### PR DESCRIPTION
Instead of requiring a local url to be configured in order to use the
remote url, the app now tries to connect using the local url first. if
this does not work (not configured or not reachable), it does the same for
the alt / remote url. And only if this fails, too, the service discovery
is started.

This makes testing of openhab-cloud locally a bit easier, and is what I
would expect as a user.