### PR TITLE
Set default theme to light

### DIFF
--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -68,7 +68,7 @@
         <ListPreference
             android:key="default_openhab_theme"
             android:title="@string/settings_openhab_theme"
-            android:defaultValue="dark"
+            android:defaultValue="@string/theme_value_light"
             android:entries="@array/themeArray"
             android:entryValues="@array/themeValues" />
         <CheckBoxPreference


### PR DESCRIPTION
Light themes are always default. The light theme uses the openHAB "orange", but the dark theme is just grey.

This also fixes the issue, that no radio button in the theme selection is checked after installation.