### PR TITLE
Fix crash if "No route to host"

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
@@ -66,7 +66,8 @@ public class OpenHABVoiceService extends ContinuingIntentService implements Open
         SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(this);
         String username = mSettings.getString(Constants.PREFERENCE_USERNAME, null);
         String password = mSettings.getString(Constants.PREFERENCE_PASSWORD, null);
-        mAsyncHttpClient = new MyAsyncHttpClient(this);
+        mAsyncHttpClient = new MyAsyncHttpClient(PreferenceManager
+                .getDefaultSharedPreferences(this).getBoolean(Constants.PREFERENCE_SSLHOST, false));
         mAsyncHttpClient.setBasicAuth(username, password);
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABInfoFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABInfoFragment.java
@@ -12,6 +12,7 @@ package org.openhab.habdroid.ui;
 
 import android.app.Dialog;
 import android.os.Bundle;
+import android.preference.PreferenceManager;
 import android.support.v4.app.DialogFragment;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -22,6 +23,7 @@ import android.widget.TextView;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.util.Constants;
 import org.openhab.habdroid.util.MyAsyncHttpClient;
 import org.openhab.habdroid.util.MyHttpClient;
 
@@ -49,7 +51,9 @@ public class OpenHABInfoFragment extends DialogFragment {
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
         View view = inflater.inflate(R.layout.openhabinfo, container);
-        mAsyncHttpClient = new MyAsyncHttpClient(getActivity().getApplicationContext());
+        mAsyncHttpClient = new MyAsyncHttpClient(PreferenceManager.getDefaultSharedPreferences
+                (getActivity().getApplicationContext())
+                .getBoolean(Constants.PREFERENCE_SSLHOST, false));
         mOpenHABVersionText = (TextView)view.findViewById(R.id.openhab_version);
         mOpenHABUUIDText = (TextView)view.findViewById(R.id.openhab_uuid);
         mOpenHABSecretText = (TextView)view.findViewById(R.id.openhab_secret);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -222,10 +222,11 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         // Set default values, false means do it one time during the very first launch
         PreferenceManager.setDefaultValues(this, R.xml.preferences, false);
 
+        SharedPreferences sharedPrefs = PreferenceManager.getDefaultSharedPreferences(this);
         // Set non-persistent HABDroid version preference to current version from application package
         try {
             Log.d(TAG, "App version = " + getPackageManager().getPackageInfo(getPackageName(), 0).versionName);
-            PreferenceManager.getDefaultSharedPreferences(this).edit().putString(Constants.PREFERENCE_APPVERSION,
+            sharedPrefs.edit().putString(Constants.PREFERENCE_APPVERSION,
                     getPackageManager().getPackageInfo(getPackageName(), 0).versionName).commit();
         } catch (PackageManager.NameNotFoundException e1) {
             Log.d(TAG, e1.getMessage());
@@ -235,7 +236,8 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         checkVoiceRecognition();
 
         // initialize loopj async http client
-        mAsyncHttpClient = new MyAsyncHttpClient(this);
+        mAsyncHttpClient = new MyAsyncHttpClient(sharedPrefs.getBoolean(Constants.PREFERENCE_SSLHOST,
+                false));
 
         // Set the theme to one from preferences
         mSettings = PreferenceManager.getDefaultSharedPreferences(this);
@@ -1227,7 +1229,9 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                 Log.d(TAG, "Could not parse the baseURL to an URL: " + ex.getMessage());
                 return null;
             }
-            MySyncHttpClient syncHttpClient = new MySyncHttpClient(this);
+            MySyncHttpClient syncHttpClient = new MySyncHttpClient(PreferenceManager
+                    .getDefaultSharedPreferences(this)
+                    .getBoolean(Constants.PREFERENCE_SSLHOST, false));
             syncHttpClient.setBasicAuth(getOpenHABUsername(), getOpenHABPassword());
             mNotifySettings = new NotificationSettings(baseUrl, syncHttpClient);
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -1229,9 +1229,10 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                 Log.d(TAG, "Could not parse the baseURL to an URL: " + ex.getMessage());
                 return null;
             }
-            MySyncHttpClient syncHttpClient = new MySyncHttpClient(PreferenceManager
-                    .getDefaultSharedPreferences(this)
-                    .getBoolean(Constants.PREFERENCE_SSLHOST, false));
+            SharedPreferences prefs = PreferenceManager.getDefaultSharedPreferences(this);
+            MySyncHttpClient syncHttpClient = new MySyncHttpClient(
+                    prefs.getBoolean(Constants.PREFERENCE_SSLHOST, false),
+                    prefs.getBoolean(Constants.PREFERENCE_SSLCERT, false));
             syncHttpClient.setBasicAuth(getOpenHABUsername(), getOpenHABPassword());
             mNotifySettings = new NotificationSettings(baseUrl, syncHttpClient);
         }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
@@ -32,6 +32,7 @@ import org.openhab.habdroid.model.OpenHABItem;
 import org.openhab.habdroid.model.OpenHABNFCActionList;
 import org.openhab.habdroid.model.OpenHABWidget;
 import org.openhab.habdroid.model.OpenHABWidgetDataSource;
+import org.openhab.habdroid.util.Constants;
 import org.openhab.habdroid.util.MyAsyncHttpClient;
 import org.openhab.habdroid.util.MyHttpClient;
 import org.openhab.habdroid.util.Util;
@@ -148,7 +149,8 @@ public class OpenHABWidgetListFragment extends ListFragment {
         openHABUsername = mActivity.getOpenHABUsername();
         openHABPassword = mActivity.getOpenHABPassword();
         // We're using atmosphere so create an own client to not block the others
-        mAsyncHttpClient = new MyAsyncHttpClient(mActivity);
+        mAsyncHttpClient = new MyAsyncHttpClient(PreferenceManager
+                .getDefaultSharedPreferences(mActivity).getBoolean(Constants.PREFERENCE_SSLHOST, false));
         mAsyncHttpClient.setBasicAuth(openHABUsername, openHABPassword);
         openHABWidgetAdapter.setOpenHABUsername(openHABUsername);
         openHABWidgetAdapter.setOpenHABPassword(openHABPassword);

--- a/mobile/src/main/java/org/openhab/habdroid/util/MyAsyncHttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MyAsyncHttpClient.java
@@ -9,7 +9,6 @@
 
 package org.openhab.habdroid.util;
 
-import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -26,8 +25,8 @@ import okhttp3.Response;
 
 public class MyAsyncHttpClient extends MyHttpClient<Call> {
 
-    public MyAsyncHttpClient(Context ctx) {
-        clientSSLSetup(ctx);
+    public MyAsyncHttpClient(Boolean ignoreSSLHostname) {
+        clientSSLSetup(ignoreSSLHostname);
 	}
 
     protected Call method(String url, String method, Map<String, String> addHeaders, String

--- a/mobile/src/main/java/org/openhab/habdroid/util/MyHttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MyHttpClient.java
@@ -9,8 +9,6 @@
 
 package org.openhab.habdroid.util;
 
-import android.content.Context;
-import android.preference.PreferenceManager;
 import android.support.annotation.NonNull;
 
 import org.apache.http.conn.ssl.SSLSocketFactory;
@@ -41,8 +39,8 @@ public abstract class MyHttpClient<T> {
     protected OkHttpClient.Builder clientBuilder = new OkHttpClient.Builder();
     protected OkHttpClient client = clientBuilder.build();
 
-    protected void clientSSLSetup(Context ctx) {
-        if (PreferenceManager.getDefaultSharedPreferences(ctx).getBoolean(Constants.PREFERENCE_SSLHOST, false)) {
+    protected void clientSSLSetup(Boolean ignoreSSLHostname) {
+        if (ignoreSSLHostname) {
             clientBuilder.hostnameVerifier(SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
             client = clientBuilder.build();
         }

--- a/mobile/src/main/java/org/openhab/habdroid/util/MySyncHttpClient.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MySyncHttpClient.java
@@ -62,7 +62,7 @@ public class MySyncHttpClient extends MyHttpClient<Response> {
             return new Response
                     .Builder()
                     .code(500)
-                    .message(ex.getMessage())
+                    .message(ex.getClass().getName() + ": " + ex.getMessage())
                     .request(request)
                     .protocol(Protocol.HTTP_1_0)
                     .build();

--- a/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
@@ -81,7 +81,9 @@ public class MyWebImage implements SmartImage {
 
     private Bitmap getBitmapFromUrl(Context context, final String url, final String iconFormat) {
         final Map<String, Object> result = new HashMap<String, Object>();
-        MyAsyncHttpClient client = new MyAsyncHttpClient(context);
+        MyAsyncHttpClient client = new MyAsyncHttpClient(PreferenceManager
+                .getDefaultSharedPreferences(context)
+                .getBoolean(Constants.PREFERENCE_SSLHOST, false));
         client.setTimeout(READ_TIMEOUT);
         if (shouldAuth) {
             client.setBasicAuth(authUsername, authPassword);

--- a/mobile/src/test/java/org/openhab/habdroid/util/MySyncHttpClientTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/util/MySyncHttpClientTest.java
@@ -17,7 +17,7 @@ public class MySyncHttpClientTest {
      */
     @Test
     public void testMethodErrorResponse() {
-        MySyncHttpClient httpClient = new MySyncHttpClient(false);
+        MySyncHttpClient httpClient = new MySyncHttpClient(false, false);
 
         String host = "just.a.local.url.local";
         Response resp = httpClient.method(

--- a/mobile/src/test/java/org/openhab/habdroid/util/MySyncHttpClientTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/util/MySyncHttpClientTest.java
@@ -1,0 +1,40 @@
+package org.openhab.habdroid.util;
+
+
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import okhttp3.Call;
+import okhttp3.Headers;
+import okhttp3.Response;
+
+import static org.junit.Assert.assertEquals;
+
+public class MySyncHttpClientTest {
+    /**
+     * Unit test against Issue #315 "Crash when connection could not be established"
+     */
+    @Test
+    public void testMethodErrorResponse() {
+        MySyncHttpClient httpClient = new MySyncHttpClient(false);
+
+        String host = "just.a.local.url.local";
+        Response resp = httpClient.method(
+                "https://" + host,
+                "GET",
+                new HashMap<String, String>(),
+                null,
+                "",
+                new MyHttpClient.ResponseHandler() {
+                    public void onFailure(Call call, int statusCode, Headers headers, byte[] responseBody,
+                                          Throwable error) {}
+
+                    public void onSuccess(Call call, int statusCode, Headers headers, byte[]
+                            responseBody) {}
+                });
+
+        assertEquals(500, resp.code());
+        assertEquals(host, resp.message());
+    }
+}

--- a/mobile/src/test/java/org/openhab/habdroid/util/MySyncHttpClientTest.java
+++ b/mobile/src/test/java/org/openhab/habdroid/util/MySyncHttpClientTest.java
@@ -3,6 +3,7 @@ package org.openhab.habdroid.util;
 
 import org.junit.Test;
 
+import java.net.UnknownHostException;
 import java.util.HashMap;
 
 import okhttp3.Call;
@@ -10,6 +11,7 @@ import okhttp3.Headers;
 import okhttp3.Response;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class MySyncHttpClientTest {
     /**
@@ -35,6 +37,6 @@ public class MySyncHttpClientTest {
                 });
 
         assertEquals(500, resp.code());
-        assertEquals(host, resp.message());
+        assertTrue(resp.message().startsWith(UnknownHostException.class.getName()));
     }
 }


### PR DESCRIPTION
If the connection to the remote host could not be established, the app
creates a fake response with the error message and status code 500 for the
notification settings sync hhtp request. However, until now, the creation
of this Fake response failed, as the Response builder requires some data,
which was not given so far.

This also refactors the MyHttpClient sslSetup method, which does not need
to get the whole context passed to it and therefore the constructors of
MyAsync and MySyncHttpClient does not need this neither. It now takes a
boolean argument, which indicates, if hostnames of a ssl cert should be
ignored or not.

Fixes #315