### PR TITLE
Update build to API 26 latest + library updates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,10 @@ If you want to contribute to Android application we are here to help you to set 
 development environment. openHAB Android app is developed using Android studio and also can be
 build with maven.
 
-- Download and install [Android Studio](http://developer.android.com/sdk/installing/studio.html)
-- After installation launch Android Studio, download and install Android SDK version 4.0.3 (Tools ->
-Android -> SDK Manager)
-- Check out the latest code from github
-- Open the project in Android Studio (File -> Open, select project folder)
+- Download and install [Android Studio](http://developer.android.com/sdk/installing/studio.html).  Should you feel adventurous, preview versions of Android Studio are also available [here](https://developer.android.com/studio/preview/index.html#linux-canary-bundle).
+- After installation, launch Android Studio.  Next, select **Tools** from the main menu, then **Android**, and choose **SDK Manager**.  Install the latest Android build tools, SDKs, and libraries (SDK Tools >= 26.0.0 and SDK Platform-Tools >=26.0.2).
+- Download the latest OpenHAB source code from github with the *git* command:  `git clone https://github.com/openhab/openhab.android.git` or download the source from [here](https://github.com/openhab/openhab.android/archive/master.zip).
+- Open the project in Android Studio (Select **File** from the main menu, then choose **Open**.  Select the OpenHAB project folder and choose **OK**.)
 
 You are ready to contribute!
 
@@ -31,7 +30,7 @@ Before producing any amount of code please have a look at [contribution guidelin
 ## Trademark Disclaimer
 
 Product names, logos, brands and other trademarks referred to within the openHAB website are the
-property of their respective trademark holders. These trademark holders are not affiliated with
-openHAB or our website. They do not sponsor or endorse our materials.
+property of their respective trademark holders.  These trademark holders are not affiliated with
+openHAB or our website.  They do not sponsor or endorse our materials.
 
-Google Play and the Google Play logo are trademarks of Google Inc.
+Google Play&trade; and the Google Play&trade; logo are trademarks of Google Inc.

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.4.0-alpha7'
+        classpath 'com.android.tools.build:gradle:3.0.0-alpha4'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Feb 15 13:56:37 PST 2017
+#Mon Jun 19 10:41:14 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip

--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -1,14 +1,14 @@
 apply plugin: 'com.android.application'
 
 android {
-    buildToolsVersion '25.0.2'
-    compileSdkVersion 25
+    buildToolsVersion '26.0.0'
+    compileSdkVersion 26
     useLibrary 'org.apache.http.legacy'
 
     defaultConfig {
         applicationId "org.openhab.habdroid"
         minSdkVersion 14
-        targetSdkVersion 25
+        targetSdkVersion 26
         multiDexEnabled = true
     }
     buildTypes {
@@ -31,6 +31,9 @@ android {
 }
 
 repositories {
+    maven {
+        url 'https://maven.google.com'
+    }
     jcenter()
     mavenCentral()
     maven {
@@ -46,22 +49,22 @@ repositories {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     wearApp project(':wear')
-    compile "com.android.support:appcompat-v7:25.3.1"
-    compile "com.android.support:support-v4:25.3.1"
-    compile "com.android.support:design:25.3.1"
+    compile "com.android.support:appcompat-v7:26.0.0-beta2"
+    compile "com.android.support:support-v4:26.0.0-beta2"
+    compile "com.android.support:design:26.0.0-beta2"
     compile 'com.android.support:multidex:1.0.1'
-    compile 'com.google.code.gson:gson:2.7'
-    compile 'com.google.android.gms:play-services-analytics:10.2.1'
-    compile 'com.google.android.gms:play-services-gcm:10.2.1'
-    compile 'com.crittercism:crittercism-android-agent:5.8.1-rc-1'
+    compile 'com.google.code.gson:gson:2.8.0'
+    compile 'com.google.android.gms:play-services-analytics:11.0.1'
+    compile 'com.google.android.gms:play-services-gcm:11.0.1'
+    compile 'com.crittercism:crittercism-android-agent:5.8.1'
     compile 'org.jmdns:jmdns:3.5.1'
-    compile 'com.squareup.okhttp3:okhttp:3.6.0'
+    compile 'com.squareup.okhttp3:okhttp:3.7.0'
     compile 'com.loopj:android-smart-image-view:1.0.0'
     compile 'com.github.shell-software:fab:1.1.2'
 
     compile 'com.github.hazzeh:androidsvg:fix-npe'
 
-    testCompile 'org.mockito:mockito-core:2.7.6'
+    testCompile 'org.mockito:mockito-core:2.8.9'
     testCompile 'junit:junit:4.12'
-    testCompile 'org.json:json:20160810'
+    testCompile 'org.json:json:20170516'
 }

--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -45,13 +45,13 @@
             android:name="org.openhab.habdroid.ui.OpenHABMainActivity"
             android:label="@string/app_name"
             android:launchMode="singleTop">
-            <!-- for Nougat -->
-            <layout
+            <!-- for Nougat commented out for now due to bug in latest aapt2-->
+            <!--layout
                 android:defaultHeight="500dp"
                 android:defaultWidth="600dp"
                 android:gravity="top|end"
                 android:minHeight="320dp"
-                android:minWidth="480dp" />
+                android:minWidth="480dp" /-->
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -2,13 +2,13 @@ apply plugin: 'com.android.application'
 
 
 android {
-    buildToolsVersion '25.0.2'
-    compileSdkVersion 25
+    buildToolsVersion '26.0.0'
+    compileSdkVersion 26
 
     defaultConfig {
         applicationId "org.openhab.habdroid"
         minSdkVersion 20
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -22,5 +22,5 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.gms:play-services-wearable:10.2.1'
+    compile 'com.google.android.gms:play-services-wearable:11.0.1'
 }


### PR DESCRIPTION
A quick update for libraries and tools to target the newest "O" stuff from Google as well as other libraries.

Note that due to a (reported fixed) bug in aapt2, the <layout> tag has been temporarily commented out of the manifest.  Not a big deal, but should be put back once the fix appears (scheduled for alpha5) for smarter multi-window support on chromebooks.

Cheers!