### PR TITLE
Do not restore state after the app was stopped

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -327,6 +327,19 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         mDrawerToggle.onConfigurationChanged(newConfig);
     }
 
+    /**
+     * Restore the fragment, which was saved in the onSaveInstanceState handler, if there's any.
+     * @param savedInstanceState
+     */
+    @Override
+    public void onRestoreInstanceState(Bundle savedInstanceState) {
+        int savedFragment = savedInstanceState.getInt("currentFragment", 0);
+        if (savedFragment != 0){
+            pager.setCurrentItem(savedFragment);
+            Log.d(TAG, String.format("Loaded current page = %d", savedFragment));
+        }
+    }
+
     @Override
     public void onResume() {
         Log.d(TAG, "onResume()");
@@ -345,44 +358,46 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         // or if state fragment returned 0 fragments (this happens sometimes and we don't yet
         // know why, so this is a workaround
         // start over the whole process
-        if (stateFragment == null || stateFragment.getFragmentList().size() == 0) {
-            stateFragment = null;
-            stateFragment = new StateRetainFragment();
-            fm.beginTransaction().add(stateFragment, "stateFragment").commit();
-            mOpenHABTracker = new OpenHABTracker(this, openHABServiceType, mServiceDiscoveryEnabled);
-            mStartedWithNetworkConnectivityInfo = NetworkConnectivityInfo.currentNetworkConnectivityInfo(this);
-            mOpenHABTracker.start();
-            // If state fragment exists and contains something then just restore the fragments
+        Boolean startOver = stateFragment == null || stateFragment.getFragmentList().size() == 0;
+        if (startOver || !NetworkConnectivityInfo.currentNetworkConnectivityInfo(this).equals(mStartedWithNetworkConnectivityInfo)) {
+            resetStateFragmentAfterResume(fm);
         } else {
-            Log.d(TAG, "State fragment found");
             // If connectivity type changed while we were in background
             // Restart the whole process
-            // TODO: this must be refactored to remove duplicate code!
             if (!NetworkConnectivityInfo.currentNetworkConnectivityInfo(this).equals(mStartedWithNetworkConnectivityInfo)) {
                 Log.d(TAG, "Connectivity type changed while I was out, or zero fragments found, need to restart");
+                resetStateFragmentAfterResume(fm);
                 // Clean up any existing fragments
                 pagerAdapter.clearFragmentList();
-                stateFragment.getFragmentList().clear();
-                stateFragment = null;
                 // Clean up title
                 this.setTitle(R.string.app_name);
-                stateFragment = new StateRetainFragment();
-                fm.beginTransaction().add(stateFragment, "stateFragment").commit();
-                mOpenHABTracker = new OpenHABTracker(this, openHABServiceType, mServiceDiscoveryEnabled);
-                mStartedWithNetworkConnectivityInfo = NetworkConnectivityInfo.currentNetworkConnectivityInfo(this);
-                mOpenHABTracker.start();
                 return;
             }
+            // If state fragment exists and contains something then just restore the fragments
+            Log.d(TAG, "State fragment found");
             pagerAdapter.setFragmentList(stateFragment.getFragmentList());
             Log.d(TAG, String.format("Loaded %d fragments", stateFragment.getFragmentList().size()));
             pager.setCurrentItem(stateFragment.getCurrentPage());
-            Log.d(TAG, String.format("Loaded current page = %d", stateFragment.getCurrentPage()));
         }
         if (!TextUtils.isEmpty(mPendingNfcPage)) {
             openNFCPageIfPending();
         }
 
         checkFullscreen();
+    }
+
+    /**
+     * Resets the state of the app and activity after a fresh start or network change was
+     * recognized. Helper method for onResume only.
+     *
+     * @param fm
+     */
+    private void resetStateFragmentAfterResume(FragmentManager fm) {
+        stateFragment = new StateRetainFragment();
+        fm.beginTransaction().add(stateFragment, "stateFragment").commit();
+        mOpenHABTracker = new OpenHABTracker(this, openHABServiceType, mServiceDiscoveryEnabled);
+        mStartedWithNetworkConnectivityInfo = NetworkConnectivityInfo.currentNetworkConnectivityInfo(this);
+        mOpenHABTracker.start();
     }
 
     /**

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
@@ -109,17 +109,6 @@ public class OpenHABWidgetListFragment extends ListFragment {
         Log.d(TAG, "isAdded = " + isAdded());
         mTag = this;
         super.onCreate(savedInstanceState);
-        if (savedInstanceState != null) {
-            Log.d(TAG, "restoring state from savedInstanceState");
-            displayPageUrl = savedInstanceState.getString("displayPageUrl");
-            openHABBaseUrl = savedInstanceState.getString("openHABBaseUrl");
-            sitemapRootUrl = savedInstanceState.getString("sitemapRootUrl");
-            openHABUsername = savedInstanceState.getString("openHABUsername");
-            openHABPassword = savedInstanceState.getString("openHABPassword");
-            mCurrentSelectedItem = savedInstanceState.getInt("currentSelectedItem", -1);
-            mPosition = savedInstanceState.getInt("position", -1);
-            Log.d(TAG, String.format("onCreate selected item = %d", mCurrentSelectedItem));
-        }
         if (getArguments() != null) {
             displayPageUrl = getArguments().getString("displayPageUrl");
             openHABBaseUrl = getArguments().getString("openHABBaseUrl");
@@ -128,9 +117,6 @@ public class OpenHABWidgetListFragment extends ListFragment {
             openHABPassword = getArguments().getString("openHABPassword");
             mPosition = getArguments().getInt("position");
         }
-        if (savedInstanceState != null)
-            if (!displayPageUrl.equals(savedInstanceState.getString("displayPageUrl")))
-                mCurrentSelectedItem = -1;
     }
 
     @Override
@@ -281,21 +267,6 @@ public class OpenHABWidgetListFragment extends ListFragment {
         Log.d(TAG, "isAdded = " + isAdded());
         if (displayPageUrl != null)
             showPage(displayPageUrl, false);
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle savedInstanceState) {
-        Log.d(TAG, "onSaveInstanceState");
-        Log.d(TAG, "isAdded = " + isAdded());
-        Log.d(TAG, String.format("onSave current selected item = %d", getListView().getCheckedItemPosition()));
-        savedInstanceState.putString("displayPageUrl", displayPageUrl);
-        savedInstanceState.putString("openHABBaseUrl", openHABBaseUrl);
-        savedInstanceState.putString("sitemapRootUrl", sitemapRootUrl);
-        savedInstanceState.putString("openHABUsername", openHABUsername);
-        savedInstanceState.putString("openHABPassword", openHABPassword);
-        savedInstanceState.putInt("currentSelectedItem", getListView().getCheckedItemPosition());
-        savedInstanceState.putInt("position", mPosition);
-        super.onSaveInstanceState(savedInstanceState);
     }
 
     @Override


### PR DESCRIPTION
Before this commit, the app tried to restore the fragments and widgets
opened before the app was closed (or killed by the system). However, this
more or less failed mostly and resulted in the problem, that, if the user
choosed a specific widget sub-section, the saved fragment was loaded (with
the title of the new fragment), instead of the new one.

This commit removes this logic. The app now does not try to restore the
state of the app anymore, after it was closed. The state is only
preserved, if the app comes to the foreground again, without being stopped
in the meantime.

Fixes #246