### PR TITLE
Fix NullPointerException when no viewBox is part of SVG

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
@@ -143,13 +143,19 @@ public class MyWebImage implements SmartImage {
         Bitmap bitmap = null;
         try {
             SVG svg = SVG.getFromInputStream(is);
-                double width = svg.getDocumentViewBox().width();
-                double height = svg.getDocumentViewBox().height();
+            double width = 16;
+            double height = 16;
+            if (svg.getDocumentViewBox() != null) {
+                width = svg.getDocumentViewBox().width();
+                height = svg.getDocumentViewBox().height();
+            } else {
+                Log.d(TAG, "DocumentViewBox is null. assuming width and heigh of 16px.");
+            }
 
-                bitmap = Bitmap.createBitmap((int) Math.ceil(width), (int) Math.ceil(height), Bitmap.Config.ARGB_8888);
-                Canvas canvas = new Canvas(bitmap);
-                canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);//drawARGB(0,0,0,0);//drawRGB(255, 255, 255);
-                svg.renderToCanvas(canvas);
+            bitmap = Bitmap.createBitmap((int) Math.ceil(width), (int) Math.ceil(height), Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(bitmap);
+            canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.CLEAR);//drawARGB(0,0,0,0);//drawRGB(255, 255, 255);
+            svg.renderToCanvas(canvas);
         } catch (SVGParseException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
SVG#getDocumentViewBox() could return null, if no viewBox is present in
the provided SVG. In this case, assume, that the SVG size is 16x16px
(probably not the best values, but if the the viewBox is missing, it's
already a pretty weird case and the behaviour is more or less undefined,
this now just prevents the app from crashing).

Fixes #330