### PR TITLE
Use popup for selection items

### DIFF
--- a/mobile/src/main/res/layout/openhabwidgetlist_selectionitem.xml
+++ b/mobile/src/main/res/layout/openhabwidgetlist_selectionitem.xml
@@ -19,7 +19,8 @@
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
         android:focusable="false"
-        android:focusableInTouchMode="false" />
+        android:focusableInTouchMode="false"
+        android:spinnerMode="dialog" />
 
     <LinearLayout
         android:id="@+id/listdivider"


### PR DESCRIPTION
This has several advantages:
1. Consistent width
2. Same behavior in app and basic ui
3. Better for tablets and large smartphones
Fixes #344 

Couldn't make a screenshot of how it is now, but here is a screenshot after:
![screenshot_2017-08-22-18-31-27](https://user-images.githubusercontent.com/22525368/29576570-9ea53e68-8768-11e7-8042-ff99d3e106bf.png)

Maybe we should add a radio button.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>