### PR TITLE
For security reasons, SSL hostname checks should be enabled by default

### DIFF
--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -53,7 +53,7 @@
             android:summary="@string/settings_openhab_sslcert_summary"
             android:title="@string/settings_openhab_sslcert" />
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:key="default_openhab_sslhost"
             android:summary="@string/settings_openhab_sslhost_summary"
             android:title="@string/settings_openhab_sslhost" />


### PR DESCRIPTION
Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>