### PR TITLE
Display images as PNG when icon format is set to SVG

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
@@ -69,7 +69,10 @@ public class MyWebImage implements SmartImage {
             	bitmap = webImageCache.get(url);
             if(bitmap == null) {
             	Log.i("MyWebImage", "Cache for " + url + " is empty, getting image");
-                final String iconFormat = PreferenceManager.getDefaultSharedPreferences(context).getString("iconFormatType","PNG");
+                String iconFormat = "PNG";
+                if (url.contains("format=SVG")) {
+                    iconFormat = "SVG";
+                }
                 bitmap = getBitmapFromUrl(context, url, iconFormat);
                 if(bitmap != null && this.useCache) {
                     webImageCache.put(url, bitmap);

--- a/mobile/src/main/res/values/arrays.xml
+++ b/mobile/src/main/res/values/arrays.xml
@@ -19,8 +19,13 @@
         <item>@string/theme_value_black</item>
     </string-array>
 
-    <string-array name="iconTypeValues">
+    <string-array name="iconTypeNames">
         <item>@string/settings_openhab_icon_format_png</item>
         <item>@string/settings_openhab_icon_format_svg</item>
+    </string-array>
+
+    <string-array name="iconTypeValues">
+        <item>@string/settings_openhab_icon_format_value_png</item>
+        <item>@string/settings_openhab_icon_format_value_svg</item>
     </string-array>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -55,8 +55,8 @@
     <string name="settings_openhab_fullscreen">Full Screen</string>
     <string name="settings_openhab_fullscreen_summary">Display in fullscreen mode</string>
     <string name="settings_openhab_icon_format">Icon format</string>
-    <string name="settings_openhab_icon_format_value_png">PNG</string>
-    <string name="settings_openhab_icon_format_value_svg">SVG</string>
+    <string name="settings_openhab_icon_format_value_png" translatable="false">PNG</string>
+    <string name="settings_openhab_icon_format_value_svg" translatable="false">SVG</string>
     <string name="settings_openhab_icon_format_png">PNG</string>
     <string name="settings_openhab_icon_format_svg">SVG</string>
     <string name="settings_ringtone">Ring tone</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -55,6 +55,8 @@
     <string name="settings_openhab_fullscreen">Full Screen</string>
     <string name="settings_openhab_fullscreen_summary">Display in fullscreen mode</string>
     <string name="settings_openhab_icon_format">Icon format</string>
+    <string name="settings_openhab_icon_format_value_png">PNG</string>
+    <string name="settings_openhab_icon_format_value_svg">SVG</string>
     <string name="settings_openhab_icon_format_png">PNG</string>
     <string name="settings_openhab_icon_format_svg">SVG</string>
     <string name="settings_ringtone">Ring tone</string>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -76,12 +76,12 @@
             android:summary="@string/settings_openhab_fullscreen_summary"
             android:title="@string/settings_openhab_fullscreen" />
         <ListPreference
-            android:title="@string/settings_openhab_icon_format"
-            android:key="iconFormatType"
             android:defaultValue="@string/settings_openhab_icon_format_png"
+            android:entries="@array/iconTypeNames"
+            android:entryValues="@array/iconTypeValues"
+            android:key="iconFormatType"
             android:summary="%s"
-            android:entries="@array/iconTypeValues"
-            android:entryValues="@array/iconTypeValues" />
+            android:title="@string/settings_openhab_icon_format" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_misc_title">
         <RingtonePreference


### PR DESCRIPTION
The problem is that all images (icons, charts and external images) are
rendered in the same format and the svg libary will fail if it gets a
png.

At this point we dont really have to read the preferences since
mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Widget.java Line
21 inserts format=(format here) in the url and we can parse this url.

Fix #286

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>

I'm not sure if that is the best solution.