### PR TITLE
Open Notifications fragment when notification is selected

### DIFF
--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="openhab_demo_url" translatable="false">http://demo.openhab.org:8080/</string>
     <string name="app_preferences_name">Settings</string>
     <string name="app_notifications">Notifications</string>
+    <string name="dlg_notification_title">Notification message</string>
     <string name="app_bindings">Bindings</string>
     <string name="app_bindings_supportedthings">Supported Things</string>
     <string name="app_discoveryinbox">Discovery</string>


### PR DESCRIPTION
If a notification from the systems notification bar is selected, the app
now opens the notifications fragment, if it is available currently
(openHAB remote url with username and password is used).

It also shows an alert box with the message content of the selected
message, if the message was added to the intent (should always happen).
This will happen regardless if the notification fragment is opened or not
to show the full message to the user (again).

Fixes #379