### PR TITLE
Listen for gadgetbridge broadcast

### DIFF
--- a/mobile/src/main/AndroidManifest.xml
+++ b/mobile/src/main/AndroidManifest.xml
@@ -105,6 +105,8 @@
                 android:name="android.appwidget.provider"
                 android:resource="@xml/voice_widget_info" />
         </receiver>
+
+        <service android:name=".core.ForegroundService" />
         <!--    This is temp disabled because of a bug in GMS 6.5
                 <meta-data android:name="com.google.android.gms.analytics.globalConfigResource"
                     android:resource="@xml/global_tracker" /> -->

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
@@ -56,8 +56,6 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
         try {
             Log.d(TAG, "onReceive()");
             if (intent.hasExtra("button_id")) {
-                Toast.makeText(context, "Got broadcast "+intent.getExtras().get("button_id"), Toast.LENGTH_SHORT).show();
-                //Log.d(TAG, "Button id " + intent.toString());
                 Log.d(TAG, "Button: " + intent.getExtras().get("button_id"));
 
                 final String state;
@@ -79,11 +77,10 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
                         public void onFailure(Call call, int statusCode, Headers headers, String responseString, Throwable error) {
                             Log.e(TAG, "Got command error " + error.getMessage());
                             String message = String.format(context.getString(R.string.notification_last_broadcast_failed), currentTime, state);
-                            updateNotification(message, context);
                             if (statusCode == 404) {
-                                String toastMessage = context.getString(R.string.error_custom_broadcast_item_not_found);
-                                Toast.makeText(context, toastMessage, Toast.LENGTH_LONG).show();
+                                message = context.getString(R.string.error_custom_broadcast_item_not_found);
                             }
+                            updateNotification(message, context);
                             if (responseString != null)
                                 Log.e(TAG, "Error response = " + responseString);
                         }

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
@@ -1,0 +1,70 @@
+package org.openhab.habdroid.core;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.SharedPreferences;
+import android.preference.PreferenceManager;
+import android.util.Log;
+import android.widget.Toast;
+
+import org.openhab.habdroid.R;
+import org.openhab.habdroid.ui.OpenHABMainActivity;
+import org.openhab.habdroid.util.Constants;
+import org.openhab.habdroid.util.MyHttpClient;
+
+import okhttp3.Call;
+import okhttp3.Headers;
+
+import static org.openhab.habdroid.ui.OpenHABMainActivity.mAsyncHttpClient;
+
+public class CustomBroadcastReceiver extends BroadcastReceiver {
+    private final static String TAG = CustomBroadcastReceiver.class.getSimpleName();
+
+    @Override
+    public void onReceive(final Context context, Intent intent) {
+        try {
+            Log.d(TAG, "onReceive()");
+            if (intent.hasExtra("button_id")) {
+                Toast.makeText(context, "Got broadcast "+intent.getExtras().get("button_id"), Toast.LENGTH_SHORT).show();
+                //Log.d(TAG, "Button id " + intent.toString());
+                Log.d(TAG, "Button: " + intent.getExtras().get("button_id"));
+
+                String state;
+                try {
+                    state = intent.getExtras().get("button_id").toString();
+                } catch (NullPointerException e) {
+                    e.printStackTrace();
+                    return;
+                }
+                SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(context);
+                String item = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_ITEM, "");
+
+                try {
+                    mAsyncHttpClient.post(OpenHABMainActivity.openHABBaseUrl + "rest/items/" + item, state, "text/plain;charset=UTF-8", new MyHttpClient.TextResponseHandler() {
+                        @Override
+                        public void onFailure(Call call, int statusCode, Headers headers, String responseString, Throwable error) {
+                            Log.e(TAG, "Got command error " + error.getMessage());
+                            if (statusCode == 404) {
+                                String message = context.getString(R.string.error_custom_broadcast_item_not_found);
+                                Toast.makeText(context, message, Toast.LENGTH_LONG).show();
+                            }
+                            if (responseString != null)
+                                Log.e(TAG, "Error response = " + responseString);
+                        }
+
+                        @Override
+                        public void onSuccess(Call call, int statusCode, Headers headers, String responseString) {
+                            Log.d(TAG, "Command was sent successfully");
+                        }
+                    });
+                } catch (RuntimeException e) {
+                    if (e.getMessage() != null)
+                        Log.e(TAG, e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
@@ -56,6 +56,7 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
                         @Override
                         public void onSuccess(Call call, int statusCode, Headers headers, String responseString) {
                             Log.d(TAG, "Command was sent successfully");
+                            // todo write text to notification
                         }
                     });
                 } catch (RuntimeException e) {

--- a/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/CustomBroadcastReceiver.java
@@ -1,10 +1,17 @@
 package org.openhab.habdroid.core;
 
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
+import android.icu.text.SimpleDateFormat;
 import android.preference.PreferenceManager;
+import android.support.annotation.Nullable;
+import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.res.ResourcesCompat;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -13,6 +20,9 @@ import org.openhab.habdroid.ui.OpenHABMainActivity;
 import org.openhab.habdroid.util.Constants;
 import org.openhab.habdroid.util.MyHttpClient;
 
+import java.util.Calendar;
+import java.util.Date;
+
 import okhttp3.Call;
 import okhttp3.Headers;
 
@@ -20,6 +30,26 @@ import static org.openhab.habdroid.ui.OpenHABMainActivity.mAsyncHttpClient;
 
 public class CustomBroadcastReceiver extends BroadcastReceiver {
     private final static String TAG = CustomBroadcastReceiver.class.getSimpleName();
+
+    private static void updateNotification(String text, Context context) {
+        Intent notificationIntent = new Intent(context, OpenHABMainActivity.class);
+        notificationIntent.setAction(Constants.ACTION.MAIN_ACTION);
+        notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+
+        PendingIntent pendingIntent =
+                PendingIntent.getActivity(context, 0, notificationIntent, 0);
+
+        Notification notification = new NotificationCompat.Builder(context)
+                .setContentTitle(context.getString(R.string.settings_custom_broadcast_listening))
+                .setContentText(text)
+                .setSmallIcon(R.drawable.openhabicon_light)
+                .setPriority(Notification.PRIORITY_LOW)
+                .setColor(ResourcesCompat.getColor(context.getResources(), R.color.openhab_orange, null))
+                .setContentIntent(pendingIntent)
+                .setOngoing(true).build();
+        NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        nm.notify(Constants.NOTIFICATION_ID.FOREGROUND_SERVICE, notification);
+    }
 
     @Override
     public void onReceive(final Context context, Intent intent) {
@@ -30,7 +60,7 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
                 //Log.d(TAG, "Button id " + intent.toString());
                 Log.d(TAG, "Button: " + intent.getExtras().get("button_id"));
 
-                String state;
+                final String state;
                 try {
                     state = intent.getExtras().get("button_id").toString();
                 } catch (NullPointerException e) {
@@ -40,14 +70,19 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
                 SharedPreferences mSettings = PreferenceManager.getDefaultSharedPreferences(context);
                 String item = mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_ITEM, "");
 
+                // todo needs api 24
+                final String currentTime = new SimpleDateFormat("HH:mm:ss").format(new Date());
+
                 try {
                     mAsyncHttpClient.post(OpenHABMainActivity.openHABBaseUrl + "rest/items/" + item, state, "text/plain;charset=UTF-8", new MyHttpClient.TextResponseHandler() {
                         @Override
                         public void onFailure(Call call, int statusCode, Headers headers, String responseString, Throwable error) {
                             Log.e(TAG, "Got command error " + error.getMessage());
+                            String message = String.format(context.getString(R.string.notification_last_broadcast_failed), currentTime, state);
+                            updateNotification(message, context);
                             if (statusCode == 404) {
-                                String message = context.getString(R.string.error_custom_broadcast_item_not_found);
-                                Toast.makeText(context, message, Toast.LENGTH_LONG).show();
+                                String toastMessage = context.getString(R.string.error_custom_broadcast_item_not_found);
+                                Toast.makeText(context, toastMessage, Toast.LENGTH_LONG).show();
                             }
                             if (responseString != null)
                                 Log.e(TAG, "Error response = " + responseString);
@@ -55,8 +90,9 @@ public class CustomBroadcastReceiver extends BroadcastReceiver {
 
                         @Override
                         public void onSuccess(Call call, int statusCode, Headers headers, String responseString) {
+                            String message = String.format(context.getString(R.string.notification_last_broadcast_success), currentTime, state);
+                            updateNotification(message, context);
                             Log.d(TAG, "Command was sent successfully");
-                            // todo write text to notification
                         }
                     });
                 } catch (RuntimeException e) {

--- a/mobile/src/main/java/org/openhab/habdroid/core/ForegroundService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/ForegroundService.java
@@ -1,6 +1,7 @@
 package org.openhab.habdroid.core;
 
 import android.app.Notification;
+import android.app.PendingIntent;
 import android.app.Service;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -31,11 +32,15 @@ public class ForegroundService extends Service {
             notificationIntent.setAction(Constants.ACTION.MAIN_ACTION);
             notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 
+            PendingIntent pendingIntent =
+                    PendingIntent.getActivity(this, 0, notificationIntent, 0);
+
             Notification notification = new NotificationCompat.Builder(this)
                     .setContentTitle(getString(R.string.settings_custom_broadcast_listening))
                     .setSmallIcon(R.drawable.openhabicon_light)
                     .setPriority(Notification.PRIORITY_LOW)
                     .setColor(ResourcesCompat.getColor(getResources(), R.color.openhab_orange, null))
+                    .setContentIntent(pendingIntent)
                     .setOngoing(true).build();
                     //.setContentText(getString(R.string.settings_custom_broadcast_listening))
 

--- a/mobile/src/main/java/org/openhab/habdroid/core/ForegroundService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/ForegroundService.java
@@ -6,6 +6,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.IBinder;
 import android.support.v4.app.NotificationCompat;
+import android.support.v4.content.res.ResourcesCompat;
 import android.util.Log;
 
 import org.openhab.habdroid.R;
@@ -31,11 +32,12 @@ public class ForegroundService extends Service {
             notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
 
             Notification notification = new NotificationCompat.Builder(this)
-                    .setContentTitle(getString(R.string.app_name))
-                    .setContentText(getString(R.string.settings_custom_broadcast_listening))
+                    .setContentTitle(getString(R.string.settings_custom_broadcast_listening))
                     .setSmallIcon(R.drawable.openhabicon_light)
                     .setPriority(Notification.PRIORITY_LOW)
+                    .setColor(ResourcesCompat.getColor(getResources(), R.color.openhab_orange, null))
                     .setOngoing(true).build();
+                    //.setContentText(getString(R.string.settings_custom_broadcast_listening))
 
             startForeground(Constants.NOTIFICATION_ID.FOREGROUND_SERVICE, notification);
 

--- a/mobile/src/main/java/org/openhab/habdroid/core/ForegroundService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/ForegroundService.java
@@ -1,0 +1,70 @@
+package org.openhab.habdroid.core;
+
+import android.app.Notification;
+import android.app.Service;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.IBinder;
+import android.support.v4.app.NotificationCompat;
+import android.util.Log;
+
+import org.openhab.habdroid.R;
+import org.openhab.habdroid.ui.OpenHABMainActivity;
+import org.openhab.habdroid.util.Constants;
+
+public class ForegroundService extends Service {
+    private static final String TAG = "ForegroundService";
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+    }
+
+    @Override
+    public int onStartCommand(Intent intent, int flags, int startId) {
+        CustomBroadcastReceiver cbr = new CustomBroadcastReceiver();
+        if (intent.getAction().equals(Constants.ACTION.STARTFOREGROUND_ACTION)) {
+            Log.i(TAG, "Received Start Foreground Intent ");
+
+            Intent notificationIntent = new Intent(this, OpenHABMainActivity.class);
+            notificationIntent.setAction(Constants.ACTION.MAIN_ACTION);
+            notificationIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
+
+            Notification notification = new NotificationCompat.Builder(this)
+                    .setContentTitle(getString(R.string.app_name))
+                    .setContentText(getString(R.string.settings_custom_broadcast_listening))
+                    .setSmallIcon(R.drawable.openhabicon_light)
+                    .setPriority(Notification.PRIORITY_LOW)
+                    .setOngoing(true).build();
+
+            startForeground(Constants.NOTIFICATION_ID.FOREGROUND_SERVICE, notification);
+
+            String broadcast = (String) intent.getExtras().get("broadcast");
+            IntentFilter cbr_intent = new IntentFilter();
+            cbr_intent.addAction(broadcast);
+            registerReceiver(cbr, cbr_intent);
+        } else if (intent.getAction().equals(Constants.ACTION.STOPFOREGROUND_ACTION)) {
+            // No API call available to check if a broadcast receiver is running: https://stackoverflow.com/questions/2682043/how-to-check-if-receiver-is-registered-in-android/3568906#3568906
+            try {
+                Log.e(TAG, "stop cbr");
+                unregisterReceiver(cbr);
+            } catch (IllegalArgumentException ignored) {}
+            Log.i(TAG, "Received Stop Foreground Intent");
+            stopForeground(true);
+            stopSelf();
+        }
+        return START_STICKY;
+    }
+
+    @Override
+    public void onDestroy() {
+        super.onDestroy();
+        Log.i(TAG, "In onDestroy");
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        // Used only in case of bound services.
+        return null;
+    }
+}

--- a/mobile/src/main/java/org/openhab/habdroid/core/ForegroundService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/ForegroundService.java
@@ -27,6 +27,10 @@ public class ForegroundService extends Service {
         CustomBroadcastReceiver cbr = new CustomBroadcastReceiver();
         if (intent.getAction().equals(Constants.ACTION.STARTFOREGROUND_ACTION)) {
             Log.i(TAG, "Received Start Foreground Intent ");
+            String broadcast = (String) intent.getExtras().get("broadcast");
+            IntentFilter cbr_intent = new IntentFilter();
+            cbr_intent.addAction(broadcast);
+            registerReceiver(cbr, cbr_intent);
 
             Intent notificationIntent = new Intent(this, OpenHABMainActivity.class);
             notificationIntent.setAction(Constants.ACTION.MAIN_ACTION);
@@ -37,19 +41,15 @@ public class ForegroundService extends Service {
 
             Notification notification = new NotificationCompat.Builder(this)
                     .setContentTitle(getString(R.string.settings_custom_broadcast_listening))
+                    .setContentText(getString(R.string.notification_last_broadcast_none))
                     .setSmallIcon(R.drawable.openhabicon_light)
                     .setPriority(Notification.PRIORITY_LOW)
                     .setColor(ResourcesCompat.getColor(getResources(), R.color.openhab_orange, null))
                     .setContentIntent(pendingIntent)
                     .setOngoing(true).build();
-                    //.setContentText(getString(R.string.settings_custom_broadcast_listening))
 
             startForeground(Constants.NOTIFICATION_ID.FOREGROUND_SERVICE, notification);
 
-            String broadcast = (String) intent.getExtras().get("broadcast");
-            IntentFilter cbr_intent = new IntentFilter();
-            cbr_intent.addAction(broadcast);
-            registerReceiver(cbr, cbr_intent);
         } else if (intent.getAction().equals(Constants.ACTION.STOPFOREGROUND_ACTION)) {
             // No API call available to check if a broadcast receiver is running: https://stackoverflow.com/questions/2682043/how-to-check-if-receiver-is-registered-in-android/3568906#3568906
             try {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -11,6 +11,7 @@ package org.openhab.habdroid.ui;
 
 import android.Manifest;
 import android.app.AlertDialog;
+import android.app.Notification;
 import android.app.PendingIntent;
 import android.app.ProgressDialog;
 import android.content.ActivityNotFoundException;
@@ -62,6 +63,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.openhab.habdroid.BuildConfig;
 import org.openhab.habdroid.R;
+import org.openhab.habdroid.core.ForegroundService;
 import org.openhab.habdroid.core.HABDroid;
 import org.openhab.habdroid.core.NetworkConnectivityInfo;
 import org.openhab.habdroid.core.NotificationDeletedBroadcastReceiver;
@@ -148,9 +150,9 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
     private static final int DRAWER_INBOX = 102;
     // Loopj
 //    private static MyAsyncHttpClient mAsyncHttpClient;
-    private static MyAsyncHttpClient mAsyncHttpClient;
+    public static MyAsyncHttpClient mAsyncHttpClient;
     // Base URL of current openHAB connection
-    private String openHABBaseUrl = "http://demo.openhab.org:8080/";
+    public static String openHABBaseUrl = "http://demo.openhab.org:8080/";
     // openHAB username
     private String openHABUsername = "";
     // openHAB password
@@ -313,6 +315,19 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             registerReceiver(dreamReceiver, new IntentFilter("android.intent.action.DREAMING_STARTED"));
             registerReceiver(dreamReceiver, new IntentFilter("android.intent.action.DREAMING_STOPPED"));
             checkFullscreen();
+        }
+        // Custom broadcast receiver
+        if(mSettings.getBoolean(Constants.PREFERENCE_CUSTOM_BROADCAST, false)) {
+            Log.d(TAG, "start cbr");
+            Intent startIntent = new Intent(this, ForegroundService.class);
+            startIntent.setAction(Constants.ACTION.STARTFOREGROUND_ACTION);
+            startIntent.putExtra("broadcast", mSettings.getString(Constants.PREFERENCE_CUSTOM_BROADCAST_BROADCAST, ""));
+            startService(startIntent);
+        } else {
+            Log.d(TAG, "stop cbr");
+            Intent stopIntent = new Intent(this, ForegroundService.class);
+            stopIntent.setAction(Constants.ACTION.STOPFOREGROUND_ACTION);
+            startService(stopIntent);
         }
     }
 

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -26,5 +26,18 @@ public class Constants {
     public static final String PREFERENCE_TONE              = "default_openhab_alertringtone";
     public static final String PREFERENCE_SSLCLIENTCERT     = "default_openhab_sslclientcert";
     public static final String PREFERENCE_SSLCLIENTCERT_HOWTO = "default_openhab_sslclientcert_howto";
+    public static final String PREFERENCE_CUSTOM_BROADCAST    = "default_openhab_custom_broadcast_enabled";
+    public static final String PREFERENCE_CUSTOM_BROADCAST_BROADCAST = "default_openhab_custom_broadcast";
+    public static final String PREFERENCE_CUSTOM_BROADCAST_ITEM = "default_openhab_custom_broadcast_item";
     public static final String DEFAULT_GCM_SENDER_ID        = "737820980945";
+
+    public interface ACTION {
+        public static String MAIN_ACTION = "org.openhab.habdroid.action.main";
+        public static String STARTFOREGROUND_ACTION = "org.openhab.habdroid.action.startforeground";
+        public static String STOPFOREGROUND_ACTION = "org.openhab.habdroid.action.stopforeground";
+    }
+
+    public interface NOTIFICATION_ID {
+        public static int FOREGROUND_SERVICE = 101;
+    }
 }

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -129,4 +129,13 @@
     <string name="about_links">Links</string>
     <string name="about_links_list"><![CDATA[\u00B7 <a href="https://github.com/openhab/openhab.android">openHAB App source code</a><br><br> \u00B7 <a href="https://github.com/openhab/openhab.android/issues">Report a problem</a><br><br> \u00B7 <a href="http://docs.openhab.org/">openHAB Documentation</a><br><br> \u00B7 <a href="https://community.openhab.org/">Community Forum</a>]]></string>
     <string name="about_copyright" translatable="false">© 2012 - %s openHAB Foundation</string>
+    <string name="settings_custom_broadcast_enabled_title">Receive custom broadcast</string>
+    <string name="settings_custom_broadcast_enabled_summary">Can be used to fetch Mi Band button presses via Gadgetbridge</string>
+    <string name="settings_custom_broadcast_broadcast" translatable="false">nodomain.freeyourgadget.gadgetbridge.mibandButtonPressed</string>
+    <string name="settings_custom_broadcast_title">Broadcast to receive</string>
+    <string name="settings_custom_broadcast_item_title">Item to change</string>
+    <string name="settings_custom_broadcast_item_summary">Item state will be set to number of button presses</string>
+    <string name="settings_custom_broadcast">Custom broadcast receiver</string>
+    <string name="error_custom_broadcast_item_not_found">Item for custom broadcasts is incorrect</string>
+    <string name="settings_custom_broadcast_listening">Listening for broadcasts</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -138,4 +138,7 @@
     <string name="settings_custom_broadcast">Custom broadcast receiver</string>
     <string name="error_custom_broadcast_item_not_found">Item for custom broadcasts is incorrect</string>
     <string name="settings_custom_broadcast_listening">Listening for broadcasts</string>
+    <string name="notification_last_broadcast_success" formatted="false">Last broadcast at %s with %s presses was successful</string>
+    <string name="notification_last_broadcast_failed" formatted="false">Last broadcast at %s with %s presses failed</string>
+    <string name="notification_last_broadcast_none">No broadcast received since start</string>
 </resources>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -83,6 +83,24 @@
             android:entries="@array/iconTypeValues"
             android:entryValues="@array/iconTypeValues" />
     </PreferenceCategory>
+    <PreferenceCategory android:title="@string/settings_custom_broadcast">
+    <CheckBoxPreference
+        android:defaultValue="false"
+        android:key="default_openhab_custom_broadcast_enabled"
+        android:summary="@string/settings_custom_broadcast_enabled_summary"
+        android:title="@string/settings_custom_broadcast_enabled_title" />
+    <EditTextPreference
+        android:defaultValue="@string/settings_custom_broadcast_broadcast"
+        android:key="default_openhab_custom_broadcast"
+        android:dependency="default_openhab_custom_broadcast_enabled"
+        android:title="@string/settings_custom_broadcast_title" />
+    <EditTextPreference
+        android:defaultValue="@string/empty_string"
+        android:key="default_openhab_custom_broadcast_item"
+        android:dependency="default_openhab_custom_broadcast_enabled"
+        android:summary="@string/settings_custom_broadcast_item_summary"
+        android:title="@string/settings_custom_broadcast_item_title" />
+    </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_misc_title">
         <RingtonePreference
             android:key="default_openhab_alertringtone"

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -84,22 +84,22 @@
             android:entryValues="@array/iconTypeValues" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_custom_broadcast">
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="default_openhab_custom_broadcast_enabled"
-        android:summary="@string/settings_custom_broadcast_enabled_summary"
-        android:title="@string/settings_custom_broadcast_enabled_title" />
-    <EditTextPreference
-        android:defaultValue="@string/settings_custom_broadcast_broadcast"
-        android:key="default_openhab_custom_broadcast"
-        android:dependency="default_openhab_custom_broadcast_enabled"
-        android:title="@string/settings_custom_broadcast_title" />
-    <EditTextPreference
-        android:defaultValue="@string/empty_string"
-        android:key="default_openhab_custom_broadcast_item"
-        android:dependency="default_openhab_custom_broadcast_enabled"
-        android:summary="@string/settings_custom_broadcast_item_summary"
-        android:title="@string/settings_custom_broadcast_item_title" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="default_openhab_custom_broadcast_enabled"
+            android:summary="@string/settings_custom_broadcast_enabled_summary"
+            android:title="@string/settings_custom_broadcast_enabled_title" />
+        <EditTextPreference
+            android:defaultValue="@string/settings_custom_broadcast_broadcast"
+            android:key="default_openhab_custom_broadcast"
+            android:dependency="default_openhab_custom_broadcast_enabled"
+            android:title="@string/settings_custom_broadcast_title" />
+        <EditTextPreference
+            android:defaultValue="@string/empty_string"
+            android:key="default_openhab_custom_broadcast_item"
+            android:dependency="default_openhab_custom_broadcast_enabled"
+            android:summary="@string/settings_custom_broadcast_item_summary"
+            android:title="@string/settings_custom_broadcast_item_title" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_misc_title">
         <RingtonePreference


### PR DESCRIPTION
This commit gives the user the ability to set up a custom broadcast receiver that changes an item on receive.

This was designed to send Mi Band 2 button presses to the openHAB server. This will only work if an app is installed, that send broadcasts on button presses. Since Gadgetbridge does so, it is the default broadcast.

I had to create a foreground service, that starts the receiver. Otherwise it would be killed by the os. Foreground services have to show a notification, but it shown as low priority, so it shouldnt disturb the user.

Before this will get merged, I want to test it on my phone if everything works fine.