### PR TITLE
Fix up GCM status printing.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABInfoFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABInfoFragment.java
@@ -188,15 +188,11 @@ public class OpenHABInfoFragment extends DialogFragment {
 
 
     private void setGcmText() {
-        String infoString;
         if (OpenHABMainActivity.GCM_SENDER_ID == null) {
-            infoString = getString(R.string.info_openhab_gcm_not_connected);
+            mOpenHABNotificationText.setText(R.string.info_openhab_gcm_not_connected);
         } else {
-            infoString = getString(R.string.info_openhab_gcm_connected);
+            mOpenHABNotificationText.setText(
+                    getString(R.string.info_openhab_gcm_connected, OpenHABMainActivity.GCM_SENDER_ID));
         }
-
-        mOpenHABNotificationText.setText(
-                String.format(infoString, OpenHABMainActivity.GCM_SENDER_ID)
-        );
     }
 }

--- a/mobile/src/main/res/values-el/strings.xml
+++ b/mobile/src/main/res/values-el/strings.xml
@@ -37,7 +37,7 @@
     <string name="info_openhab_apiversion_label">Έκδοση openHAB Rest API</string>
     <string name="info_openhab_gcm_connected">Εγγραφή συσκευής με ID αποστολέα %s</string>
     <string name="info_openhab_gcm_label">Κατάσταση Μηνύματος Google Cloud</string>
-    <string name="info_openhab_gcm_not_connected">Η εγγραφή συσκευής με ID αποστολέα %s απέτυχε</string>
+    <string name="info_openhab_gcm_not_connected">Η εγγραφή συσκευής απέτυχε</string>
     <string name="info_openhab_secret_label">Μυστικό openHAB</string>
     <string name="info_openhab_uuid_label">openHAB UUID</string>
     <string name="info_openhab_version_label">Έκδοση openHAB</string>

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -79,7 +79,7 @@
     <string name="info_openhab_uuid_label">UUID openHAB</string>
     <string name="info_openhab_secret_label">Phrase secrète openHAB</string>
     <string name="info_openhab_gcm_label">Google Cloud Message</string>
-    <string name="info_openhab_gcm_not_connected">Echec de l\'enregistrement de l\'appareil avec l\'ID %s</string>
+    <string name="info_openhab_gcm_not_connected">Echec de l\'enregistrement de l\'appareil</string>
     <string name="info_openhab_gcm_connected">Appareil enregistré avec l\'ID %s</string>
     <string name="action_settings">Paramétrage</string>
     <string name="nfc_dialog_title">Sélectionner une action pour le tag NFC</string>

--- a/mobile/src/main/res/values-ru/strings.xml
+++ b/mobile/src/main/res/values-ru/strings.xml
@@ -84,7 +84,6 @@
     <string name="info_openhab_uuid_label">openHAB UUID</string>
     <string name="info_openhab_secret_label">openHAB Secret</string>
     <string name="info_openhab_gcm_label">Google Cloud Статус Сообщения</string>
-    <string name="info_openhab_gcm_not_connected">Ошибка регистрации устройства с отправленным ID %s</string>
     <string name="info_openhab_gcm_connected">Устройство зарегистрировано с отправленным ID %s</string>
     <string name="action_settings">Параметры</string>
     <string name="nfc_dialog_title">Выберите действие тега NFC</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -92,7 +92,7 @@
     <string name="info_openhab_uuid_label">openHAB UUID</string>
     <string name="info_openhab_secret_label">openHAB Secret</string>
     <string name="info_openhab_gcm_label">Google Cloud Message Status</string>
-    <string name="info_openhab_gcm_not_connected">Device registration failed with Sender ID %s</string>
+    <string name="info_openhab_gcm_not_connected">Device registration failed</string>
     <string name="info_openhab_gcm_connected">Registered device with Sender ID %s</string>
     <string name="action_settings">Settings</string>
     <string name="nfc_dialog_title">Please select NFC tag action</string>


### PR DESCRIPTION
Use the string formatting built into getString(), and don't print the ID
if it's known to be null anyway.

Signed-off-by: Danny Baumann <dannybaumann@web.de>