### PR TITLE
Remove permission checks for permissions needed for discovery.

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABTracker.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABTracker.java
@@ -42,8 +42,6 @@ public class OpenHABTracker implements AsyncServiceResolverListener {
     private final static String TAG = OpenHABTracker.class.getSimpleName();
     // Context in which openhabtracker is working
     Context mCtx;
-    // If bonjour discovery is enabled?
-    boolean mDiscoveryEnabled;
     // receiver for openhabtracker notifications
     OpenHABTrackerReceiver mReceiver;
     // openHAB URL
@@ -55,9 +53,8 @@ public class OpenHABTracker implements AsyncServiceResolverListener {
     // Receiver for connectivity tracking
     ConnectivityChangeReceiver mConnectivityChangeReceiver;
 
-    public OpenHABTracker(Context ctx, String serviceType, boolean discoveryEnabled) {
+    public OpenHABTracker(Context ctx, String serviceType) {
         mCtx = ctx;
-        mDiscoveryEnabled = discoveryEnabled;
         // If context is implementing our callback interface, set it as a receiver automatically
         if (ctx instanceof OpenHABTrackerReceiver) {
             mReceiver = (OpenHABTrackerReceiver)ctx;

--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
@@ -81,7 +81,7 @@ public class OpenHABVoiceService extends ContinuingIntentService implements Open
             onOpenHABTracked(intent.getStringExtra(OPENHAB_BASE_URL_EXTRA), null);
         } else if (mOpenHABTracker == null) {
             Log.d(TAG, "No openHABBaseUrl passed, starting OpenHABTracker");
-            mOpenHABTracker = new OpenHABTracker(OpenHABVoiceService.this, getString(R.string.openhab_service_type), false);
+            mOpenHABTracker = new OpenHABTracker(OpenHABVoiceService.this, getString(R.string.openhab_service_type));
             mOpenHABTracker.start();
         }
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -9,7 +9,6 @@
 
 package org.openhab.habdroid.ui;
 
-import android.Manifest;
 import android.app.AlertDialog;
 import android.app.PendingIntent;
 import android.app.ProgressDialog;
@@ -174,8 +173,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
     private ProgressDialog mProgressDialog;
     // If Voice Recognition is enabled
     private boolean mVoiceRecognitionEnabled = false;
-    // If openHAB discovery is enabled
-    private boolean mServiceDiscoveryEnabled = true;
     // NFC Launch data
     private String mNfcData;
     // Pending NFC page
@@ -242,7 +239,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
             Log.d(TAG, e1.getMessage());
         }
 
-        checkDiscoveryPermissions();
         checkVoiceRecognition();
 
         // initialize loopj async http client
@@ -417,7 +413,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
     private void resetStateFragmentAfterResume(FragmentManager fm) {
         stateFragment = new StateRetainFragment();
         fm.beginTransaction().add(stateFragment, "stateFragment").commit();
-        mOpenHABTracker = new OpenHABTracker(this, openHABServiceType, mServiceDiscoveryEnabled);
+        mOpenHABTracker = new OpenHABTracker(this, openHABServiceType);
         mStartedWithNetworkConnectivityInfo = NetworkConnectivityInfo.currentNetworkConnectivityInfo(this);
         mOpenHABTracker.start();
     }
@@ -1163,20 +1159,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         if (activities.size() != 0) {
             mVoiceRecognitionEnabled = true;
         }
-    }
-
-    public void checkDiscoveryPermissions() {
-        // Check if we got all needed permissions
-        PackageManager pm = getPackageManager();
-        if (!(pm.checkPermission(Manifest.permission.CHANGE_WIFI_MULTICAST_STATE, getPackageName()) == PackageManager.PERMISSION_GRANTED)) {
-            showAlertDialog(getString(R.string.erorr_no_wifi_mcast_permission));
-            mServiceDiscoveryEnabled = false;
-        }
-        if (!(pm.checkPermission(Manifest.permission.ACCESS_WIFI_STATE, getPackageName()) == PackageManager.PERMISSION_GRANTED)) {
-            showAlertDialog(getString(R.string.erorr_no_wifi_state_permission));
-            mServiceDiscoveryEnabled = false;
-        }
-
     }
 
     public void makeDecision(int decisionId, String certMessage) {

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -61,8 +61,6 @@
     <string name="error_network_not_available">Netzwerk nicht verfügbar</string>
     <string name="error_no_uuid">Konnte openHAB UUID nicht abrufen, Verbindung fehlgeschlagen</string>
     <string name="erorr_invalid_url">Bitte geben Sie eine gültige URL im \'protocol://host:port/\' format an.</string>
-    <string name="erorr_no_wifi_mcast_permission">CHANGE_WIFI_MULTICAST_STATE permission wurde nicht erteilt, openHAB discovery wird daher deaktivert!</string>
-    <string name="erorr_no_wifi_state_permission">ACCESS_WIFI_STATE permission wurde nicht erteilt, openHAB discovery wird daher deaktiviert!</string>
     <string name="error_connection_failed">Verbindung fehlgeschlagen</string>
     <string name="error_connection_sslhandshake_failed">SSL Handshake fehlgeschlagen - Sie brauchen vielleicht ein gültiges Client Zertifikat</string>
     <string name="title_activity_openhabwritetag">Schreibe NFC Tag</string>

--- a/mobile/src/main/res/values-es/strings.xml
+++ b/mobile/src/main/res/values-es/strings.xml
@@ -58,8 +58,6 @@
     <string name="error_network_not_available">La conexión de red no está disponible</string>
     <string name="error_no_uuid">No se puede obtener la openHAB UUID, conexión fallida</string>
     <string name="erorr_invalid_url">Por favor, introducir una URL válida con formato \'protocolo://host:puerto/\'</string>
-    <string name="erorr_no_wifi_mcast_permission">El permiso CHANGE_WIFI_MULTICAST_STATE no ha sido otorgado, ¡la búsqueda de openHAB será deshabilitada!</string>
-    <string name="erorr_no_wifi_state_permission">El permiso ACCESS_WIFI_STATE no ha sido otorgado, ¡la búsqueda de openHAB será deshabilitada!</string>
     <string name="error_connection_failed">Ha fallado la conexión con el host</string>
     <string name="title_activity_openhabwritetag">Escribir etiqueta NFC</string>
     <string name="title_activity_openhabinfo">Información openHAB</string>

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -62,8 +62,6 @@
     <string name="error_network_not_available">Aucune connexion réseau disponible</string>
     <string name="error_no_uuid">Récupération de l\'UUID openHAB impossible. La connexion a échoué</string>
     <string name="erorr_invalid_url">Entrez une adresse valide au format \'protocole://domaine_ou_IP:port/\' </string>
-    <string name="erorr_no_wifi_mcast_permission">Les droits CHANGE_WIFI_MULTICAST_STATE n\'ont pas été accordés à l\'application par le système Android. La découverte automatique sera désactivée.</string>
-    <string name="erorr_no_wifi_state_permission">Les droits ACCESS_WIFI_STATE n\'ont pas été accordés à l\'application par le système Android. La découverte automatique sera désactivée.</string>
     <string name="error_connection_failed">Connexion au domaine échouée</string>
     <string name="error_connection_sslhandshake_failed">Echec de la négociation SSL. Vous devriez peut-être vérifier la validité de votre certificat client</string>
     <string name="title_activity_openhabwritetag">Écrire un tag NFC</string>

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -60,8 +60,6 @@
     <string name="error_network_not_available">ネットワークが利用できません</string>
     <string name="error_no_uuid">openHAB UUID を取得できませんでした。接続に失敗しました</string>
     <string name="erorr_invalid_url">\'protocol://host:port/\' の形式で、正しい URL を入力してください</string>
-    <string name="erorr_no_wifi_mcast_permission">CHANGE_WIFI_MULTICAST_STATE アクセス許可が付与されていません。 openHAB の探索は無効になります!</string>
-    <string name="erorr_no_wifi_state_permission">ACCESS_WIFI_STATE アクセス許可が付与されていません。 openHAB の探索は無効になります!</string>
     <string name="error_connection_failed">ホストへの接続に失敗しました</string>
     <string name="error_connection_sslhandshake_failed">SSL ハンドシェイクに失敗しました - 有効なクライアント証明書が必要かもしれません</string>
     <string name="title_activity_openhabwritetag">NFC タグを書き込み</string>

--- a/mobile/src/main/res/values-lt/strings.xml
+++ b/mobile/src/main/res/values-lt/strings.xml
@@ -60,8 +60,6 @@
     <string name="error_network_not_available">Tinklas nepasiekiamas</string>
     <string name="error_no_uuid">Nepavyko gauti openHAB UUID, ryšys nutrauktas</string>
     <string name="erorr_invalid_url">Prašome įvesti adresą \'protocol://host:port/\' pavidalu</string>
-    <string name="erorr_no_wifi_mcast_permission">Leidimas CHANGE_WIFI_MULTICAST_STATE nėra suteiktas, openHAB aptikimas bus išjungtas!</string>
-    <string name="erorr_no_wifi_state_permission">Leidimas ACCESS_WIFI_STATE nėra suteiktas, openHAB aptikimas bus išjungtas!</string>
     <string name="error_connection_failed">Nepavyko prisijungti prie serverio</string>
     <string name="error_connection_sslhandshake_failed">Nepavyko užmegzti SSL ryšio - gal jums reikia galiojančio kliento sertifikato</string>
     <string name="title_activity_openhabwritetag">Rašyti NFC žymą</string>

--- a/mobile/src/main/res/values-nl/strings.xml
+++ b/mobile/src/main/res/values-nl/strings.xml
@@ -58,8 +58,6 @@
     <string name="error_network_not_available">Netwerk is niet beschikbaar</string>
     <string name="error_no_uuid">openHAB UUID kan niet opgevraagd worden, connectie mislukt</string>
     <string name="erorr_invalid_url">Vul een correcte URL in deze \'protocol://host:port/\' vorm</string>
-    <string name="erorr_no_wifi_mcast_permission">CHANGE_WIFI_MULTICAST_STATE permissie is niet gegeven, openHAB ontdekken wordt uitgeschakeld!</string>
-    <string name="erorr_no_wifi_state_permission">ACCESS_WIFI_STATE permissie is niet gegeven, openHAB ontdekken wordt uitgeschakeld!</string>
     <string name="error_connection_failed">Verbinding met host mislukt</string>
     <string name="title_activity_openhabwritetag">Schrijf NFC-tag</string>
     <string name="title_activity_openhabinfo">openHAB Informatie</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -75,8 +75,6 @@
     <string name="error_network_not_available">Network is not available</string>
     <string name="error_no_uuid">Unable to get openHAB UUID, connection failed</string>
     <string name="erorr_invalid_url">Please enter a valid URL in a \'protocol://host:port/\' form</string>
-    <string name="erorr_no_wifi_mcast_permission">CHANGE_WIFI_MULTICAST_STATE permission is not granted, openHAB discovery will be disabled!</string>
-    <string name="erorr_no_wifi_state_permission">ACCESS_WIFI_STATE permission is not granted, openHAB discovery will be disabled!</string>
     <string name="error_connection_failed">Connection to host failed</string>
     <string name="error_connection_sslhandshake_failed">SSL Handshake failed - maybe you need a valid client certificate</string>
     <string name="title_activity_openhabwritetag">Write NFC tag</string>


### PR DESCRIPTION
That check introduced hard to translate, technical strings, and its
outcome wasn't actually used anyway.

Signed-off-by: Danny Baumann <dannybaumann@web.de>