### PR TITLE
Fixed Greek translation for gcm status printing

### DIFF
--- a/mobile/src/main/res/values-el/strings.xml
+++ b/mobile/src/main/res/values-el/strings.xml
@@ -37,7 +37,7 @@
     <string name="info_openhab_apiversion_label">Έκδοση openHAB Rest API</string>
     <string name="info_openhab_gcm_connected">Εγγραφή συσκευής με ID αποστολέα %s</string>
     <string name="info_openhab_gcm_label">Κατάσταση Μηνύματος Google Cloud</string>
-    <string name="info_openhab_gcm_not_connected">Η εγγραφή συσκευής με ID αποστολέα %s απέτυχε</string>
+    <string name="info_openhab_gcm_not_connected">Η εγγραφή συσκευής απέτυχε</string>
     <string name="info_openhab_secret_label">Μυστικό openHAB</string>
     <string name="info_openhab_uuid_label">openHAB UUID</string>
     <string name="info_openhab_version_label">Έκδοση openHAB</string>


### PR DESCRIPTION
This PR fixes the Greek translation info_openhab_gcm_not_connected String referenced in PR #337