### PR TITLE
Always use altUrl for Notificatiosn fragment

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/notifications/NotificationSettings.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/notifications/NotificationSettings.java
@@ -22,6 +22,8 @@ public class NotificationSettings {
     private static final String GCM_SENDER_ID_KEY = "senderId";
 
     private URL openHABCloudURL;
+    private String openHABCloudUsername;
+    private String openHABCloudPassword;
     private MySyncHttpClient httpClient;
     private JSONObject settings = new JSONObject();
     private boolean isLoaded = false;
@@ -47,6 +49,22 @@ public class NotificationSettings {
     public NotificationSettings(URL openHABCloudURL, MySyncHttpClient httpClient) {
         this.openHABCloudURL = openHABCloudURL;
         this.httpClient = httpClient;
+    }
+
+    public String getOpenHABCloudUsername() {
+        return openHABCloudUsername;
+    }
+
+    public void setOpenHABCloudUsername(String openHABCloudUsername) {
+        this.openHABCloudUsername = openHABCloudUsername;
+    }
+
+    public String getOpenHABCloudPassword() {
+        return openHABCloudPassword;
+    }
+
+    public void setOpenHABCloudPassword(String openHABCloudPassword) {
+        this.openHABCloudPassword = openHABCloudPassword;
     }
 
     MyHttpClient getHttpClient () {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABFragmentPagerAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABFragmentPagerAdapter.java
@@ -9,13 +9,14 @@
 
 package org.openhab.habdroid.ui;
 
-import android.support.v4.app.ListFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.app.ListFragment;
 import android.support.v4.view.ViewPager;
 import android.util.Log;
 
+import org.openhab.habdroid.core.notifications.NotificationSettings;
 import org.openhab.habdroid.model.thing.ThingType;
 
 import java.util.ArrayList;
@@ -133,21 +134,35 @@ public class OpenHABFragmentPagerAdapter extends FragmentStatePagerAdapter imple
         return columnsNumber;
     }
 
-    public void openNotifications() {
+    /**
+     * This method assumes, that a remote URL (altUrl) is set and always uses this one, instead
+     * of the currently used URL to connect to openHAB. Notifications are always handled in the
+     * remote url, if there's any. However, the caller of this method must ensure, that this
+     * method is not called, when no openHAB remote URL is set.
+     */
+    public void openNotifications(NotificationSettings notificationSettings) {
         if (fragmentList.size() > 0) {
             if (!(fragmentList.get(fragmentList.size() - 1) instanceof OpenHABNotificationFragment)) {
                 removeLastFragmentIfNotWidgetList();
-                OpenHABNotificationFragment fragment = new OpenHABNotificationFragment().newInstance(openHABBaseUrl, openHABUsername, openHABPassword);
+                OpenHABNotificationFragment fragment = getNewNotificationFragment(notificationSettings);
                 fragmentList.add(fragment);
                 notifyDataSetChanged();
             } else {
                 ((OpenHABNotificationFragment) fragmentList.get(fragmentList.size() - 1)).refresh();
             }
         } else {
-            OpenHABNotificationFragment fragment = new OpenHABNotificationFragment().newInstance(openHABBaseUrl, openHABUsername, openHABPassword);
+            OpenHABNotificationFragment fragment = getNewNotificationFragment(notificationSettings);
             fragmentList.add(fragment);
             notifyDataSetChanged();
         }
+    }
+
+    private OpenHABNotificationFragment getNewNotificationFragment(NotificationSettings notificationSettings) {
+        return new OpenHABNotificationFragment().newInstance(
+                notificationSettings.getOpenHABCloudURL().toString(),
+                notificationSettings.getOpenHABCloudUsername(),
+                notificationSettings.getOpenHABCloudPassword()
+        );
     }
 
     public void openBindings() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -9,8 +9,6 @@
 
 package org.openhab.habdroid.ui;
 
-import android.Manifest;
-import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.PendingIntent;
@@ -101,7 +99,6 @@ import java.security.cert.CertificateNotYetValidException;
 import java.security.cert.CertificateRevokedException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.locks.ReentrantLock;
 
 import javax.net.ssl.SSLHandshakeException;
 import javax.xml.parsers.DocumentBuilder;
@@ -847,7 +844,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
 
     public void openNotifications() {
         if (this.pagerAdapter != null) {
-            pagerAdapter.openNotifications();
+            pagerAdapter.openNotifications(getNotificationSettings());
             pager.setCurrentItem(pagerAdapter.getCount() - 1);
         }
     }
@@ -1353,6 +1350,10 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                     prefs.getBoolean(Constants.PREFERENCE_SSLCERT, false));
             syncHttpClient.setBasicAuth(getOpenHABUsername(), getOpenHABPassword());
             mNotifySettings = new NotificationSettings(baseUrl, syncHttpClient);
+            mNotifySettings.setOpenHABCloudUsername(
+                    mSettings.getString(Constants.PREFERENCE_USERNAME, openHABUsername));
+            mNotifySettings.setOpenHABCloudPassword(
+                    mSettings.getString(Constants.PREFERENCE_PASSWORD, openHABPassword));
         }
         return mNotifySettings;
     }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABNotificationAdapter.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABNotificationAdapter.java
@@ -20,7 +20,6 @@ import android.widget.TextView;
 
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.model.OpenHABNotification;
-import org.openhab.habdroid.util.Constants;
 import org.openhab.habdroid.util.MySmartImageView;
 
 import java.util.ArrayList;
@@ -83,6 +82,6 @@ public class OpenHABNotificationAdapter extends ArrayAdapter<OpenHABNotification
     }
 
     public void setOpenHABBaseUrl(String mOpenHABBaseUrl) {
-        this.mOpenHABPassword = mOpenHABBaseUrl;
+        this.mOpenHABBaseUrl = mOpenHABBaseUrl;
     }
 }

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABNotificationFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABNotificationFragment.java
@@ -122,6 +122,9 @@ public class OpenHABNotificationFragment extends ListFragment implements SwipeRe
     public void onActivityCreated(Bundle savedInstanceState) {
         super.onActivityCreated(savedInstanceState);
         mNotificationAdapter = new OpenHABNotificationAdapter(this.getActivity(), R.layout.openhabnotificationlist_item, mNotifications);
+        mNotificationAdapter.setOpenHABBaseUrl(openHABBaseURL);
+        mNotificationAdapter.setOpenHABUsername(openHABUsername);
+        mNotificationAdapter.setOpenHABPassword(openHABPassword);
         getListView().setAdapter(mNotificationAdapter);
         Log.d(TAG, "onActivityCreated()");
         Log.d(TAG, "isAdded = " + isAdded());


### PR DESCRIPTION
Accessing notifications with the local URL can't work, as the local URL is
mostly the openHAB URL directly, which does not provide the expected
notifications api. Instead, if a remote URL is set, use this for the
notifications fragment always.

Fixes #253