### PR TITLE
Move the clear image cache from the options to the settings menu

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -47,7 +47,6 @@ import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Gravity;
-import android.view.KeyEvent;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
@@ -59,7 +58,6 @@ import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import com.google.android.gms.gcm.GoogleCloudMessaging;
-import com.loopj.android.image.WebImageCache;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -74,7 +72,6 @@ import org.openhab.habdroid.core.notifications.GoogleCloudMessageConnector;
 import org.openhab.habdroid.core.notifications.NotificationSettings;
 import org.openhab.habdroid.model.OpenHABLinkedPage;
 import org.openhab.habdroid.model.OpenHABSitemap;
-import org.openhab.habdroid.model.thing.ThingType;
 import org.openhab.habdroid.ui.drawer.OpenHABDrawerAdapter;
 import org.openhab.habdroid.ui.drawer.OpenHABDrawerItem;
 import org.openhab.habdroid.util.Constants;
@@ -872,20 +869,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                 preferencesEditor.putString(Constants.PREFERENCE_SITEMAP, "");
                 preferencesEditor.apply();
                 selectSitemap(openHABBaseUrl, true, true);
-                return true;
-            case R.id.mainmenu_openhab_clearcache:
-                Log.d(TAG, "Restarting");
-                // Get launch intent for application
-                Intent restartIntent = getBaseContext().getPackageManager()
-                        .getLaunchIntentForPackage(getBaseContext().getPackageName());
-                restartIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-                // Finish current activity
-                finish();
-                WebImageCache cache = new WebImageCache(getBaseContext());
-                cache.clear();
-                // Start launch activity
-                startActivity(restartIntent);
-                // Start launch activity
                 return true;
             case R.id.mainmenu_openhab_writetag:
                 Intent writeTagIntent = new Intent(this.getApplicationContext(), OpenHABWriteTagActivity.class);

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
@@ -29,13 +29,11 @@ import android.view.MenuItem;
 
 import com.loopj.android.image.WebImageCache;
 
-import org.openhab.habdroid.BuildConfig;
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.util.Constants;
 import org.openhab.habdroid.util.Util;
 
 import java.security.cert.X509Certificate;
-import java.text.DateFormat;
 
 /**
  * This is a class to provide preferences activity for application.
@@ -146,11 +144,8 @@ public class OpenHABPreferencesActivity extends AppCompatActivity {
             clearCachePreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
                 @Override
                 public boolean onPreferenceClick(Preference preference) {
-                    if (getActivity() == null) {
-                        return false;
-                    }
                     // Get launch intent for application
-                    Intent restartIntent = getActivity().getBaseContext().getPackageManager()
+                    Intent restartIntent = getActivity().getPackageManager()
                             .getLaunchIntentForPackage(getActivity().getBaseContext().getPackageName());
                     restartIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     // Finish current activity

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
@@ -27,7 +27,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 
-import java.text.DateFormat;
+import com.loopj.android.image.WebImageCache;
 
 import org.openhab.habdroid.BuildConfig;
 import org.openhab.habdroid.R;
@@ -35,6 +35,7 @@ import org.openhab.habdroid.util.Constants;
 import org.openhab.habdroid.util.Util;
 
 import java.security.cert.X509Certificate;
+import java.text.DateFormat;
 
 /**
  * This is a class to provide preferences activity for application.
@@ -96,6 +97,8 @@ public class OpenHABPreferencesActivity extends AppCompatActivity {
             final Preference sslClientCert = getPreferenceScreen().findPreference(Constants.PREFERENCE_SSLCLIENTCERT);
             final Preference sslClientCertHowTo = getPreferenceScreen().findPreference(Constants.PREFERENCE_SSLCLIENTCERT_HOWTO);
             final Preference altUrlPreference = getPreferenceScreen().findPreference(Constants.PREFERENCE_ALTURL);
+            final Preference clearCachePreference = getPreferenceScreen().findPreference(Constants
+                    .PREFERENCE_CLEAR_CACHE);
 
             updateSslClientCertSummary(sslClientCert);
 
@@ -140,6 +143,27 @@ public class OpenHABPreferencesActivity extends AppCompatActivity {
                     if (intent.resolveActivity(getActivity().getPackageManager()) != null) {
                         startActivity(intent);
                     }
+                    return true;
+                }
+            });
+
+            clearCachePreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    if (getActivity() == null) {
+                        return false;
+                    }
+                    // Get launch intent for application
+                    Intent restartIntent = getActivity().getBaseContext().getPackageManager()
+                            .getLaunchIntentForPackage(getActivity().getBaseContext().getPackageName());
+                    restartIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
+                    // Finish current activity
+                    getActivity().finish();
+                    WebImageCache cache = new WebImageCache(getActivity().getBaseContext());
+                    cache.clear();
+                    // Start launch activity
+                    startActivity(restartIntent);
+                    // Start launch activity
                     return true;
                 }
             });

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
@@ -31,6 +31,7 @@ import com.loopj.android.image.WebImageCache;
 
 import org.openhab.habdroid.R;
 import org.openhab.habdroid.util.Constants;
+import org.openhab.habdroid.util.MyWebImage;
 import org.openhab.habdroid.util.Util;
 
 import java.security.cert.X509Certificate;
@@ -150,8 +151,10 @@ public class OpenHABPreferencesActivity extends AppCompatActivity {
                     restartIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
                     // Finish current activity
                     getActivity().finish();
-                    WebImageCache cache = new WebImageCache(getActivity().getBaseContext());
-                    cache.clear();
+                    WebImageCache cache = MyWebImage.getWebImageCache();
+                    if (cache != null) {
+                        cache.clear();
+                    }
                     // Start launch activity
                     startActivity(restartIntent);
                     // Start launch activity

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -22,7 +22,7 @@ public class Constants {
     public static final String PREFERENCE_ANIMATION         = "default_openhab_animation";
     public static final String PREFERENCE_DEMOMODE          = "default_openhab_demomode";
     public static final String PREFERENCE_FULLSCREEN        = "default_openhab_fullscreen";
-    public static final String PREFERENCE_TONE              = "default_openhab_alertringtone";
+    public static final String PREFERENCE_CLEAR_CACHE       = "default_openhab_cleacache";
     public static final String PREFERENCE_SSLCLIENTCERT     = "default_openhab_sslclientcert";
     public static final String PREFERENCE_SSLCLIENTCERT_HOWTO = "default_openhab_sslclientcert_howto";
     public static final String PREFERENCE_DEBUG_MESSAGES      = "default_openhab_debug_messages";

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -22,6 +22,7 @@ public class Constants {
     public static final String PREFERENCE_ANIMATION         = "default_openhab_animation";
     public static final String PREFERENCE_DEMOMODE          = "default_openhab_demomode";
     public static final String PREFERENCE_FULLSCREEN        = "default_openhab_fullscreen";
+    public static final String PREFERENCE_TONE              = "default_openhab_alertringtone";
     public static final String PREFERENCE_CLEAR_CACHE       = "default_openhab_cleacache";
     public static final String PREFERENCE_SSLCLIENTCERT     = "default_openhab_sslclientcert";
     public static final String PREFERENCE_SSLCLIENTCERT_HOWTO = "default_openhab_sslclientcert_howto";

--- a/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/MyWebImage.java
@@ -55,18 +55,38 @@ public class MyWebImage implements SmartImage {
     	this.useCache = useCache;
         this.setAuthentication(username, password);
     }
-    
-    public Bitmap getBitmap(Context context) {
-        // Don't leak context
-        if(webImageCache == null) {
-            webImageCache = new WebImageCache(context);
+
+    /**
+     * Returns the already initialized WebImageCache, if there's any. This method may return
+     * null if {@link MyWebImage#getWebImageCache(Context ctx)} was not called so far.
+     *
+     * @return WebImageCache|null
+     */
+    public static WebImageCache getWebImageCache() {
+        return webImageCache;
+    }
+
+    /**
+     * See {@link MyWebImage#getWebImageCache()}, with the difference, that this method does not
+     * return null.
+     *
+     * @param ctx
+     * @return WebImageCache
+     */
+    public static WebImageCache getWebImageCache(Context ctx) {
+        if (webImageCache == null) {
+            webImageCache = new WebImageCache(ctx);
         }
 
-        // Try getting bitmap from cache first
+        return webImageCache;
+    }
+
+    public Bitmap getBitmap(Context context) {
+                // Try getting bitmap from cache first
         Bitmap bitmap = null;
         if(url != null) {
             if (this.useCache)
-            	bitmap = webImageCache.get(url);
+            	bitmap = getWebImageCache(context).get(url);
             if(bitmap == null) {
             	Log.i("MyWebImage", "Cache for " + url + " is empty, getting image");
                 String iconFormat = "PNG";
@@ -75,7 +95,7 @@ public class MyWebImage implements SmartImage {
                 }
                 bitmap = getBitmapFromUrl(context, url, iconFormat);
                 if(bitmap != null && this.useCache) {
-                    webImageCache.put(url, bitmap);
+                    getWebImageCache(context).put(url, bitmap);
                 }
             }
         }
@@ -166,7 +186,7 @@ public class MyWebImage implements SmartImage {
     }
 
     public static void removeFromCache(String url) {
-        if(webImageCache != null) {
+        if(getWebImageCache() != null) {
             webImageCache.remove(url);
         }
     }

--- a/mobile/src/main/res/menu/main_menu.xml
+++ b/mobile/src/main/res/menu/main_menu.xml
@@ -19,11 +19,6 @@
         android:title="@string/mainmenu_openhab_selectsitemap"
         app:showAsAction="never" />
     <item
-        android:id="@+id/mainmenu_openhab_clearcache"
-        android:orderInCategory="103"
-        android:title="@string/mainmenu_openhab_clearcache"
-        app:showAsAction="never" />
-    <item
         android:id="@+id/mainmenu_openhab_info"
         android:orderInCategory="104"
         android:title="@string/mainmenu_openhab_info"

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -72,6 +72,10 @@
             android:summary="%s"
             android:entries="@array/iconTypeValues"
             android:entryValues="@array/iconTypeValues" />
+        <Preference
+            android:clickable="true"
+            android:key="default_openhab_cleacache"
+            android:title="@string/mainmenu_openhab_clearcache" />
         <CheckBoxPreference
             android:defaultValue="false"
             android:key="default_openhab_screentimeroff"


### PR DESCRIPTION
The possibility to clear the image cache is not an option to the currently
viewed sitemap or section or whatever. It also shouldn't be necessary to
have this option in such a prominent component as the options menu.
Therefore, and for preparation to remove the options menu completely, the
menu is moved to the settings (next to the icon type selection).

Fixes #478