### PR TITLE
Fix crash #471

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -590,7 +590,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
      * @param logLevel can be on of Constants.MESSAGES.LOGLEVEL.*
      */
     public void showMessageToUser(String message, int messageType, int logLevel) {
-        if (message == null) {
+        if (isFinishing() || message == null) {
             return;
         }
         boolean debugEnabled = mSettings.getBoolean(Constants.PREFERENCE_DEBUG_MESSAGES, false);


### PR DESCRIPTION
The problem is that I couldnt find a way to reproduce, so I cannot test if that really fixes the problem. I have the "fix" from here: https://stackoverflow.com/questions/18662239/android-view-windowmanagerbadtokenexception-unable-to-add-window-on-buider-s/31986885#31986885

Fixes #471 