### PR TITLE
Improve discovery 

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/IntroActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/IntroActivity.java
@@ -17,7 +17,7 @@ public class IntroActivity extends AppIntro {
         // Add slides
         addOHSlide(R.string.intro_welcome, R.string.intro_whatis, R.drawable.icon_blank);
         addOHSlide(R.string.intro_themes, R.string.intro_themes_description, R.drawable.themes);
-        addOHSlide(R.string.settings_openhab_demomode, R.string.info_demo_mode, R.drawable.demo_mode);
+        addOHSlide(R.string.intro_discovery, R.string.intro_discovery_summary, R.drawable.demo_mode);
         // Change bar color
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.M) {
             setBarColor(getColor(R.color.openhab_orange));

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -168,7 +168,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
 //    private static MyAsyncHttpClient mAsyncHttpClient;
     private static MyAsyncHttpClient mAsyncHttpClient;
     // Base URL of current openHAB connection
-    private String openHABBaseUrl = "http://demo.openhab.org:8080/";
+    private String openHABBaseUrl = "https://demo.openhab.org:8443/";
     // openHAB username
     private String openHABUsername = "";
     // openHAB password

--- a/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/AsyncServiceResolver.java
@@ -93,8 +93,7 @@ public class AsyncServiceResolver extends Thread implements ServiceListener {
                 });
                 shutdown();
             }
-        } catch (InterruptedException e) {
-        }
+        } catch (InterruptedException ignored) {}
     }
 
     public void serviceAdded(ServiceEvent event) {
@@ -106,6 +105,7 @@ public class AsyncServiceResolver extends Thread implements ServiceListener {
     }
 
     public void serviceResolved(ServiceEvent event) {
+        Log.d(TAG, "serviceResolved()");
         mResolvedServiceInfo = event.getInfo();
         mIsResolved = true;
         new Handler(Looper.getMainLooper()).post(new Runnable() {

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -45,7 +45,6 @@
     <string name="title_voice_widget">openHAB-Sprachbefehl</string>
     <string name="info_voice_input">"openHAB, zu Ihren Diensten!"</string>
     <string name="info_voice_recognized_text">"Erkannter Befehl: %1$s"</string>
-    <string name="info_demo_mode">openHAB läuft im Demomodus. In den Einstellungen kann ein eigener openHAB-Server konfiguriert werden.</string>
     <string name="info_conn_url">Verbinde mit lokaler URL</string>
     <string name="info_conn_rem_url">Verbinde mit Remote-URL</string>
     <string name="info_discovery">Suche openHAB. Bitte warten\u2026</string>

--- a/mobile/src/main/res/values-el/strings.xml
+++ b/mobile/src/main/res/values-el/strings.xml
@@ -19,7 +19,6 @@
     <string name="error_no_uuid">Αδυναμία λήψης του openHAB UUID, η σύνδεση απέτυχε.</string>
     <string name="info_conn_rem_url">Σύνδεση στην απομακρυσμένη διεύθυνση</string>
     <string name="info_conn_url">Σύνδεση στην τοπική διεύθυνση</string>
-    <string name="info_demo_mode">Εκτέλεση σε κατάσταση παρουσίασης (demo). Για να συνδεθείτε στον διακομιστή openHAB σας παρακαλώ πηγαίνετε στο μενού των ρυθμίσεων.</string>
     <string name="info_discovery">Ανεύρεση openHAB. Παρακαλώ περιμένετε...</string>
     <string name="info_not_set">Δεν έχει ρυθμιστεί</string>
     <string name="info_openhab_apiversion_label">Έκδοση openHAB Rest API</string>

--- a/mobile/src/main/res/values-es/strings.xml
+++ b/mobile/src/main/res/values-es/strings.xml
@@ -37,7 +37,6 @@
     <string name="title_voice_widget">Comandos de voz openHAB</string>
     <string name="info_voice_input">"openHAB, ¡a tus órdenes!"</string>
     <string name="info_voice_recognized_text">"Comando reconocido: %1$s"</string>
-    <string name="info_demo_mode">openHAB App se ejecuta en modo demo. Por favor, ir al menú configuración para conectarlo a openHAB.</string>
     <string name="info_conn_url">Conectando a la URL local</string>
     <string name="info_conn_rem_url">Conectando a la URL remota</string>
     <string name="info_discovery">Buscando openHAB. Por favor, espera\u2026</string>

--- a/mobile/src/main/res/values-fr/strings.xml
+++ b/mobile/src/main/res/values-fr/strings.xml
@@ -44,7 +44,6 @@
     <string name="title_voice_widget">Commandes vocales openHAB</string>
     <string name="info_voice_input">openHAB, à vos ordres!"</string>
     <string name="info_voice_recognized_text">"Commande identifiée: %1$s"</string>
-    <string name="info_demo_mode">L\'app openHAB fonctionne en mode démo. Pour connecter votre instance openHAB, rendez-vous dans les paramètres de l\'application</string>
     <string name="info_demo_mode_short">Exécution en mode démo</string>
     <string name="info_conn_url">Connexion à l\'adresse locale</string>
     <string name="info_conn_rem_url">Connexion à l\'adresse distante</string>

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -39,7 +39,6 @@
     <string name="title_voice_widget">openHAB 音声コマンド</string>
     <string name="info_voice_input">"openHAB, お話ください!"</string>
     <string name="info_voice_recognized_text">"認識したコマンド: %1$s"</string>
-    <string name="info_demo_mode">openHAB はデモモードで実行中です。 お使いの openHAB に接続するには、設定メニューに移動してください。</string>
     <string name="info_conn_url">設定した URL に接続しています</string>
     <string name="info_conn_rem_url">リモート URL に接続しています</string>
     <string name="info_discovery">openHAB を探索しています。 しばらくお待ちください\u2026</string>

--- a/mobile/src/main/res/values-lt/strings.xml
+++ b/mobile/src/main/res/values-lt/strings.xml
@@ -46,7 +46,6 @@
     <string name="title_voice_widget">openHAB balso komandos</string>
     <string name="info_voice_input">\"openHAB, jūsų paliepimu!\"</string>
     <string name="info_voice_recognized_text">\"Neatpažinta komanda: %1$s\"</string>
-    <string name="info_demo_mode">openHAB programėlė veikia demonstraciniu režimu. Norėdami prisijungti prie savo openHAB serverio, eikite į nustatymų meniu.</string>
     <string name="info_conn_url">Jungiamasi prie sukonfigūruoto URL</string>
     <string name="info_conn_rem_url">Jungiamasi prie nuotolinio URL</string>
     <string name="info_discovery">Aptinkamas openHAB. Prašome palaukti\u2026</string>

--- a/mobile/src/main/res/values-nl/strings.xml
+++ b/mobile/src/main/res/values-nl/strings.xml
@@ -37,7 +37,6 @@
     <string name="title_voice_widget">openHAB stem commando\'s</string>
     <string name="info_voice_input">"openHAB, at your command!"</string>
     <string name="info_voice_recognized_text">"Herkend commando: %1$s"</string>
-    <string name="info_demo_mode">openHAB App draait in demo mode. Gebruik het instellingenmenu om met je eigen systeem te verbinden</string>
     <string name="info_conn_url">Verbinden met ingestelde URL</string>
     <string name="info_conn_rem_url">Verbinden naar externe URL</string>
     <string name="info_discovery">Ontdekken van openHAB. Moment geduld\u2026</string>

--- a/mobile/src/main/res/values-ru/strings.xml
+++ b/mobile/src/main/res/values-ru/strings.xml
@@ -48,7 +48,6 @@
     <string name="title_voice_widget">openHAB Голосовые команды</string>
     <string name="info_voice_input">"openHAB, Ваша команда!"</string>
     <string name="info_voice_recognized_text">"Принятая команда: %1$s"</string>
-    <string name="info_demo_mode">Запущен демо режим. Что бы подключиться к Вашему openHAB серверу пожалуйста зайдите в меню настройки.</string>
     <string name="info_demo_mode_short">Запущен демо режим</string>
     <string name="info_conn_url">Подключение к локальному URL</string>
     <string name="info_conn_rem_url">Подключение к удаленному URL</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -150,7 +150,7 @@
     <string name="intro_whatis">A vendor and technology agnostic open source automation software for your home</string>
     <string name="intro_themes">Themes</string>
     <string name="intro_themes_description">Choose between several themes</string>
-    <string name="error_no_url_start_demo_mode">You need an openHAB server to use this app. Please go to settings to enter IP or DNS. Demo mode will be started now.</string>
+    <string name="error_no_url_start_demo_mode">Please configure the server IP address or host name in the server settings. For now, demo mode will be used.</string>
     <string name="intro_discovery">Discovery</string>
-    <string name="intro_discovery_summary">openHAB for Android tries to find the openHAB server automatically. This will not work, when authentication is enforced.</string>
+    <string name="intro_discovery_summary">Please note this will work only if authentication is not enforced by the server</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -52,7 +52,6 @@
     <string name="title_voice_widget">openHAB Voice Commands</string>
     <string name="info_voice_input">"openHAB, at your command!"</string>
     <string name="info_voice_recognized_text">"Recognized command: %1$s"</string>
-    <string name="info_demo_mode">Running in demo mode. To connect to your openHAB server please go to settings menu.</string>
     <string name="info_demo_mode_short">Running in demo mode</string>
     <string name="info_conn_url">Connecting to local URL</string>
     <string name="info_conn_rem_url">Connecting to remote URL</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -2,8 +2,8 @@
 <resources xmlns:tools="http://schemas.android.com/tools" tools:ignore="MissingTranslation">
     <!-- General app strings -->
     <string name="app_name" translatable="false">openHAB</string>
-    <string name="openhab_service_type" translatable="false">_openhab-server-ssl._tcp.local.</string>
-    <string name="openhab_demo_url" translatable="false">http://demo.openhab.org:8080/</string>
+    <string name="openhab_service_type" translatable="false">_openhab-server._tcp.local.</string>
+    <string name="openhab_demo_url" translatable="false">https://demo.openhab.org:8443/</string>
     <string name="main_menu">Main menu</string>
     <string name="app_preferences_name">Settings</string>
     <string name="app_notifications">Notifications</string>
@@ -151,4 +151,7 @@
     <string name="intro_whatis">A vendor and technology agnostic open source automation software for your home</string>
     <string name="intro_themes">Themes</string>
     <string name="intro_themes_description">Choose between several themes</string>
+    <string name="error_no_url_start_demo_mode">You need an openHAB server to use this app. Please go to settings to enter IP or DNS. Demo mode will be started now.</string>
+    <string name="intro_discovery">Discovery</string>
+    <string name="intro_discovery_summary">openHAB for Android tries to find the openHAB server automatically. This will not work, when authentication is enforced.</string>
 </resources>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -2,7 +2,7 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
     <PreferenceCategory android:title="@string/settings_connection_title">
         <CheckBoxPreference
-            android:defaultValue="true"
+            android:defaultValue="false"
             android:disableDependentsState="true"
             android:key="default_openhab_demomode"
             android:summary="@string/settings_openhab_demomode_summary"


### PR DESCRIPTION
- Demo mode is disabled by default and only enable it if no urls are
configured and bonjour fails. Fixes #179
- Save discovered url in settings. Fixes #11 and #248 
- Inform the user that the app tries to discover oh and if that failes
it informs the user that the demo mode will be enabled. Fixes #8
- Use https for demo mode
- Discover http oh, not https. I think most people just use the default
certificate. Certificate warnings have to be turned off to make this working, so this
adds no security at all.
- Only discover when no url is set.