### PR TITLE
Remove some unused ressources

### DIFF
--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -4,9 +4,6 @@
     <string name="main_menu">Hauptmenü</string>
     <string name="app_preferences_name">Einstellungen</string>
     <string name="app_notifications">Benachrichtigungen</string>
-    <string name="app_bindings">Bindings</string>
-    <string name="minus">-</string>
-    <string name="plus">+</string>
     <!-- Main menu items -->
     <string name="mainmenu_openhab_preferences">Einstellungen</string>
     <string name="mainmenu_openhab_selectsitemap">Standard-Sitemap auswählen</string>
@@ -30,7 +27,6 @@
     <string name="settings_openhab_demomode">Demomodus</string>
     <string name="settings_openhab_demomode_summary">Demo-Daten an Stelle von realen Server-Daten verwenden</string>
     <string name="settings_openhab_theme">Design</string>
-    <string name="settings_openhab_appversion">openHAB-App-Version</string>
     <string name="settings_openhab_sslcert">SSL-Zertifikat ignorieren</string>
     <string name="settings_openhab_sslcert_summary">Beim SSL-Handshake alle Zertifikate unabhängig von ihrer Gültigkeit akzeptieren</string>
     <string name="settings_openhab_sslhost">SSL-Hostnamen ignorieren</string>
@@ -38,8 +34,6 @@
     <string name="settings_openhab_fullscreen">Vollbild</string>
     <string name="settings_openhab_fullscreen_summary">Geräte-Statusleiste während der Verwendung der App ausblenden</string>
     <string name="settings_openhab_icon_format">Symbol-Format</string>
-    <string name="settings_openhab_icon_format_png">PNG</string>
-    <string name="settings_openhab_icon_format_svg">SVG</string>
     <string name="settings_ringtone">Klingelton</string>
     <!-- App messages strings -->
     <string name="title_voice_widget">openHAB-Sprachbefehl</string>

--- a/mobile/src/main/res/values-el/strings.xml
+++ b/mobile/src/main/res/values-el/strings.xml
@@ -5,7 +5,6 @@
     <string name="about_links_list"><![CDATA[· <a href="https://github.com/openhab/openhab.android">Πηγαίος κώδικας εφαρμογής openHAB</a><br><br> · <a href="https://github.com/openhab/openhab.android/issues">Αναφορά Προβλήματος</a><br><br> · <a href="http://docs.openhab.org/">Έγγραφα τεκμηρίωσης του openHAB</a><br><br> · <a href="https://community.openhab.org/">Τόπος συζητήσεως κοινότητας</a>]]></string>
     <string name="about_title">Σχετικά</string>
     <string name="action_settings">Ρυθμίσεις</string>
-    <string name="app_bindings">Συνδέσεις</string>
     <string name="app_notifications">Ενημερώσεις</string>
     <string name="app_preferences_name">Ρυθμίσεις</string>
     <string name="drawer_close">Συρτάρι-κλειστό</string>
@@ -38,7 +37,6 @@
     <string name="info_write_tag_progress">Εγγραφή ετικέτας NFC</string>
     <string name="info_write_tag_unsupported">Αυτή η συσκευή δεν υποστηρίζει NFC</string>
     <string name="mainmenu_openhab_clearcache">Καθάρισμα κρυφής μνήμης</string>
-    <string name="mainmenu_openhab_info">Πληροφορίες openHAB</string>
     <string name="mainmenu_openhab_preferences">Ρυθμίσεις</string>
     <string name="mainmenu_openhab_selectsitemap">Προκαθορισμένο Sitemap</string>
     <string name="mainmenu_openhab_writetag">Εγγραφή ετικέτας NFC</string>
@@ -56,7 +54,6 @@
     <string name="settings_misc_title">Διάφορες Ρυθμίσεις</string>
     <string name="settings_openhab_alturl">Απομακρυσμένη διεύθυνση openHAB</string>
     <string name="settings_openhab_alturl_summary">Απομακρυσμένη διεύθυνση openHAB (χρησιμοποιείται όταν το τοπικό openHAB δεν είναι διαθέσιμο)</string>
-    <string name="settings_openhab_appversion">Έκδοση openHAB App</string>
     <string name="settings_openhab_demomode">Κατάσταση επίδειξης</string>
     <string name="settings_openhab_demomode_summary">Εκτέλεση σε κατάσταση επίδειξης</string>
     <string name="settings_openhab_fullscreen">Πλήρης Οθόνη</string>
@@ -85,8 +82,4 @@
     <string name="title_voice_widget">Φωνητικές εντολές openHAB</string>
     <string name="favorites">Αγαπημένα</string>
     <string name="main_menu">Κεντρικό Μενού</string>
-    <string name="minus">-</string>
-    <string name="plus">+</string>
-    <string name="settings_openhab_icon_format_png">PNG</string>
-    <string name="settings_openhab_icon_format_svg">SVG</string>
 </resources>

--- a/mobile/src/main/res/values-es/strings.xml
+++ b/mobile/src/main/res/values-es/strings.xml
@@ -3,12 +3,10 @@
     <!-- General app strings -->
     <string name="app_preferences_name">Configuración</string>
     <string name="app_notifications">Notificaciones</string>
-    <string name="app_bindings">Bindings</string>
     <!-- Main menu items -->
     <string name="mainmenu_openhab_preferences">Configuración</string>
     <string name="mainmenu_openhab_selectsitemap">Seleccionar el sitemap por defecto</string>
     <string name="mainmenu_openhab_writetag">Escribir una tag NFC</string>
-    <string name="mainmenu_openhab_info">Acerca de openHAB</string>
     <string name="mainmenu_openhab_clearcache">Borrar la caché de imágenes</string>
     <!-- App settings strings -->
     <string name="settings_connection_title">Configuración de la conexión</string>
@@ -25,7 +23,6 @@
     <string name="settings_openhab_demomode">Modo demo</string>
     <string name="settings_openhab_demomode_summary">Ejecutar openHAB App modo demo</string>
     <string name="settings_openhab_theme">Tema openHAB App</string>
-    <string name="settings_openhab_appversion">Versión openHAB App</string>
     <string name="settings_openhab_sslcert">Ignorar certificado SSL</string>
     <string name="settings_openhab_sslcert_summary">No comprobar el certificado durante la conexión SSL</string>
     <string name="settings_openhab_sslhost">Ignorar dominio SSL</string>

--- a/mobile/src/main/res/values-ja/strings.xml
+++ b/mobile/src/main/res/values-ja/strings.xml
@@ -3,12 +3,10 @@
     <!-- General app strings -->
     <string name="app_preferences_name">設定</string>
     <string name="app_notifications">通知</string>
-    <string name="app_bindings">バインド</string>
     <!-- Main menu items -->
     <string name="mainmenu_openhab_preferences">設定</string>
     <string name="mainmenu_openhab_selectsitemap">デフォルトのサイトマップを選択</string>
     <string name="mainmenu_openhab_writetag">NFC タグを書き込み</string>
-    <string name="mainmenu_openhab_info">openHAB 情報</string>
     <string name="mainmenu_openhab_clearcache">画像キャッシュをクリア</string>
     <!-- App settings strings -->
     <string name="settings_connection_title">接続設定</string>
@@ -27,7 +25,6 @@
     <string name="settings_openhab_demomode">デモモード</string>
     <string name="settings_openhab_demomode_summary">デモモードで openHAB を実行します</string>
     <string name="settings_openhab_theme">openHAB テーマ</string>
-    <string name="settings_openhab_appversion">openHAB バージョン</string>
     <string name="settings_openhab_sslcert">SSL 証明書を無視する</string>
     <string name="settings_openhab_sslcert_summary">SSL ハンドシェイクの間、証明書の検証を無効にします</string>
     <string name="settings_openhab_sslhost">SSL ホスト名を無効にする</string>

--- a/mobile/src/main/res/values-lt/strings.xml
+++ b/mobile/src/main/res/values-lt/strings.xml
@@ -4,15 +4,11 @@
     <string name="main_menu">Pagrindinis meniu</string>
     <string name="app_preferences_name">Nustatymai</string>
     <string name="app_notifications">Pranešimai</string>
-    <string name="app_bindings">Bindings</string>
     <string name="favorites">Mėgstami</string>
-    <string name="minus">-</string>
-    <string name="plus">+</string>
     <!-- Main menu items -->
     <string name="mainmenu_openhab_preferences">Nustatymai</string>
     <string name="mainmenu_openhab_selectsitemap">Pasirinkite numatytą vietos išplanavimą</string>
     <string name="mainmenu_openhab_writetag">Rašyti NFC žymą</string>
-    <string name="mainmenu_openhab_info">openHAB informacija</string>
     <string name="mainmenu_openhab_clearcache">Išvalyti paveikslėlių podėlį</string>
     <!-- App settings strings -->
     <string name="settings_connection_title">Ryšio nustatymai</string>
@@ -31,7 +27,6 @@
     <string name="settings_openhab_demomode">Demonstracinis režimas</string>
     <string name="settings_openhab_demomode_summary">Naudoti openHAB programėlę demonstraciniu režimu</string>
     <string name="settings_openhab_theme">openHAB tema</string>
-    <string name="settings_openhab_appversion">openHAB programėlės versija</string>
     <string name="settings_openhab_sslcert">Netikrinti SSL sertifikato</string>
     <string name="settings_openhab_sslcert_summary">Netikrinti SSL sertifikato validumo</string>
     <string name="settings_openhab_sslhost">Netikrinti SSL hostname</string>
@@ -39,8 +34,6 @@
     <string name="settings_openhab_fullscreen">Pilnas ekranas</string>
     <string name="settings_openhab_fullscreen_summary">Rodyti pilno ekrano režimu</string>
     <string name="settings_openhab_icon_format">Piktogramų formatas</string>
-    <string name="settings_openhab_icon_format_png">PNG</string>
-    <string name="settings_openhab_icon_format_svg">SVG</string>
     <string name="settings_ringtone">Skambėjimo melodija</string>
     <!-- App messages strings -->
     <string name="title_voice_widget">openHAB balso komandos</string>

--- a/mobile/src/main/res/values-nl/strings.xml
+++ b/mobile/src/main/res/values-nl/strings.xml
@@ -3,12 +3,10 @@
     <!-- General app strings -->
     <string name="app_preferences_name">Instellingen</string>
     <string name="app_notifications">Notificaties</string>
-    <string name="app_bindings">Bindings</string>
     <!-- Main menu items -->
     <string name="mainmenu_openhab_preferences">Instellingen</string>
     <string name="mainmenu_openhab_selectsitemap">Selecteer standaard sitemap</string>
     <string name="mainmenu_openhab_writetag">Schrijf NFC tag</string>
-    <string name="mainmenu_openhab_info">openHAB info</string>
     <string name="mainmenu_openhab_clearcache">Verwijder afbeeldingscache</string>
     <!-- App settings strings -->
     <string name="settings_connection_title">Verbindingsinstellingen</string>
@@ -25,7 +23,6 @@
     <string name="settings_openhab_demomode">Demo mode</string>
     <string name="settings_openhab_demomode_summary">Gebruik de openHAB App in demo modus</string>
     <string name="settings_openhab_theme">openHAB App thema</string>
-    <string name="settings_openhab_appversion">openHAB App Versie</string>
     <string name="settings_openhab_sslcert">Negeer SSL-certificaat</string>
     <string name="settings_openhab_sslcert_summary">Negeer certificaatvalidatie tijdens SSL-verificatie</string>
     <string name="settings_openhab_sslhost">Negeer SSL-hostnaam</string>

--- a/mobile/src/main/res/values-ru/strings.xml
+++ b/mobile/src/main/res/values-ru/strings.xml
@@ -5,15 +5,11 @@
     <string name="app_preferences_name">Настройки</string>
     <string name="app_notifications">Уведомления</string>
     <string name="dlg_notification_title">Уведомление</string>
-    <string name="app_bindings">Привязывать</string>
     <string name="favorites">Избранное</string>
-    <string name="minus">-</string>
-    <string name="plus">+</string>
     <!-- Main menu items -->
     <string name="mainmenu_openhab_preferences">Параметры</string>
     <string name="mainmenu_openhab_selectsitemap">Выбрать sitemap по умолчанию</string>
     <string name="mainmenu_openhab_writetag">Запись NFC tag</string>
-    <string name="mainmenu_openhab_info">openHAB Инфо</string>
     <string name="mainmenu_openhab_clearcache">Очистить кеш картинок</string>
     <!-- App settings strings -->
     <string name="settings_connection_title">Параметры Подключения</string>
@@ -33,7 +29,6 @@
     <string name="settings_openhab_demomode">Демо режим</string>
     <string name="settings_openhab_demomode_summary">Запуск демо режима</string>
     <string name="settings_openhab_theme">openHAB Тема</string>
-    <string name="settings_openhab_appversion">Версия openHAB приложения</string>
     <string name="settings_openhab_sslcert">Игнорировать SSL сертификат</string>
     <string name="settings_openhab_sslcert_summary">Игнорировать проверку сертификата во время установления SSL-соединения</string>
     <string name="settings_openhab_sslhost">Игнорировать SSL Имя хоста</string>
@@ -41,8 +36,6 @@
     <string name="settings_openhab_fullscreen">Во весь экран</string>
     <string name="settings_openhab_fullscreen_summary">Дисплей в полноэкранном режиме</string>
     <string name="settings_openhab_icon_format">Формат иконок</string>
-    <string name="settings_openhab_icon_format_png">PNG</string>
-    <string name="settings_openhab_icon_format_svg">SVG</string>
     <string name="settings_ringtone">Рингтон</string>
     <!-- App messages strings -->
     <string name="title_voice_widget">openHAB Голосовые команды</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -10,8 +10,6 @@
     <string name="dlg_notification_title">Notification message</string>
     <string name="favorites">Favorites</string>
     <string name="empty_string" translatable="false"></string>
-    <string name="minus">-</string>
-    <string name="plus">+</string>
     <!-- Main menu items -->
     <string name="mainmenu_openhab_preferences">Settings</string>
     <string name="mainmenu_openhab_selectsitemap">Select default sitemap</string>


### PR DESCRIPTION
The strings settings_openhab_icon_format_png and settings_openhab_icon_format_svg are still in use, but the original string changed, so I remove them here and the translator can translate the new string.

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>