### PR TITLE
Move "Select default sitemap" to Preferences

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABMainActivity.java
@@ -564,14 +564,14 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                     mOpenHABVersion = 1;
                     Log.d(TAG, "openHAB version 1 - got error " + throwable + " accessing " + url);
                     mAsyncHttpClient.addHeader("Accept", "application/xml");
-                    selectSitemap(openHABBaseUrl, false, false);
+                    selectSitemap(openHABBaseUrl);
                 }
 
                 @Override
                 public void onSuccess(Call call, int statusCode, Headers headers, String responseString) {
                     mOpenHABVersion = 2;
                     Log.d(TAG, "openHAB version 2");
-                    selectSitemap(openHABBaseUrl, false, false);
+                    selectSitemap(openHABBaseUrl);
                 }
             });
         }
@@ -708,7 +708,7 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
      * @return void
      */
 
-    private void selectSitemap(final String baseUrl, final boolean forceSelect, final boolean cancelable) {
+    private void selectSitemap(final String baseUrl) {
         Log.d(TAG, "Loading sitemap list from " + baseUrl + "rest/sitemaps");
         setProgressIndicatorVisible(true);
         mAsyncHttpClient.get(baseUrl + "rest/sitemaps", new DefaultHttpResponseHandler() {
@@ -747,38 +747,21 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                     return;
                 }
                 loadDrawerItems();
-                // If we are forced to do selection, just open selection dialog
-                if (forceSelect) {
-                    showSitemapSelectionDialog(mSitemapList, cancelable);
-                } else {
-                    // Check if we have a sitemap configured to use
-                    SharedPreferences settings =
-                            PreferenceManager.getDefaultSharedPreferences(OpenHABMainActivity.this);
-                    String configuredSitemap = settings.getString(Constants.PREFERENCE_SITEMAP, "");
-                    // If we have sitemap configured
-                    if (configuredSitemap.length() > 0) {
-                        // Configured sitemap is on the list we got, open it!
-                        if (Util.sitemapExists(mSitemapList, configuredSitemap)) {
-                            Log.d(TAG, "Configured sitemap is on the list");
-                            OpenHABSitemap selectedSitemap = Util.getSitemapByName(mSitemapList, configuredSitemap);
-                            openSitemap(selectedSitemap.getHomepageLink());
-                            // Configured sitemap is not on the list we got!
-                        } else {
-                            Log.d(TAG, "Configured sitemap is not on the list");
-                            if (mSitemapList.size() == 1) {
-                                Log.d(TAG, "Got only one sitemap");
-                                SharedPreferences.Editor preferencesEditor = settings.edit();
-                                preferencesEditor.putString(Constants.PREFERENCE_SITEMAP, mSitemapList.get(0).getName());
-                                preferencesEditor.apply();
-                                openSitemap(mSitemapList.get(0).getHomepageLink());
-                            } else {
-                                Log.d(TAG, "Got multiply sitemaps, user have to select one");
-                                showSitemapSelectionDialog(mSitemapList, cancelable);
-                            }
-                        }
-                        // No sitemap is configured to use
+
+                // Check if we have a sitemap configured to use
+                SharedPreferences settings =
+                        PreferenceManager.getDefaultSharedPreferences(OpenHABMainActivity.this);
+                String configuredSitemap = settings.getString(Constants.PREFERENCE_SITEMAP, "");
+                // If we have sitemap configured
+                if (configuredSitemap.length() > 0) {
+                    // Configured sitemap is on the list we got, open it!
+                    if (Util.sitemapExists(mSitemapList, configuredSitemap)) {
+                        Log.d(TAG, "Configured sitemap is on the list");
+                        OpenHABSitemap selectedSitemap = Util.getSitemapByName(mSitemapList, configuredSitemap);
+                        openSitemap(selectedSitemap.getHomepageLink());
+                        // Configured sitemap is not on the list we got!
                     } else {
-                        // We got only one single sitemap from openHAB, use it
+                        Log.d(TAG, "Configured sitemap is not on the list");
                         if (mSitemapList.size() == 1) {
                             Log.d(TAG, "Got only one sitemap");
                             SharedPreferences.Editor preferencesEditor = settings.edit();
@@ -787,15 +770,28 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
                             openSitemap(mSitemapList.get(0).getHomepageLink());
                         } else {
                             Log.d(TAG, "Got multiply sitemaps, user have to select one");
-                            showSitemapSelectionDialog(mSitemapList, cancelable);
+                            showSitemapSelectionDialog(mSitemapList);
                         }
+                    }
+                    // No sitemap is configured to use
+                } else {
+                    // We got only one single sitemap from openHAB, use it
+                    if (mSitemapList.size() == 1) {
+                        Log.d(TAG, "Got only one sitemap");
+                        SharedPreferences.Editor preferencesEditor = settings.edit();
+                        preferencesEditor.putString(Constants.PREFERENCE_SITEMAP, mSitemapList.get(0).getName());
+                        preferencesEditor.apply();
+                        openSitemap(mSitemapList.get(0).getHomepageLink());
+                    } else {
+                        Log.d(TAG, "Got multiply sitemaps, user have to select one");
+                        showSitemapSelectionDialog(mSitemapList);
                     }
                 }
             }
         });
     }
 
-    private void showSitemapSelectionDialog(final List<OpenHABSitemap> sitemapList, final boolean cancelable) {
+    private void showSitemapSelectionDialog(final List<OpenHABSitemap> sitemapList) {
         Log.d(TAG, "Opening sitemap selection dialog");
         final List<String> sitemapNameList = new ArrayList<String>();
         for (int i = 0; i < sitemapList.size(); i++) {
@@ -803,7 +799,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
         }
         AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(OpenHABMainActivity.this);
         dialogBuilder.setTitle(getString(R.string.mainmenu_openhab_selectsitemap));
-        dialogBuilder.setCancelable(cancelable);
         try {
             selectSitemapDialog = dialogBuilder.setItems(sitemapNameList.toArray(new CharSequence[sitemapNameList.size()]),
                     new DialogInterface.OnClickListener() {
@@ -876,14 +871,6 @@ public class OpenHABMainActivity extends AppCompatActivity implements OnWidgetSe
 
         //menu items
         switch (item.getItemId()) {
-            case R.id.mainmenu_openhab_selectsitemap:
-                SharedPreferences settings =
-                        PreferenceManager.getDefaultSharedPreferences(OpenHABMainActivity.this);
-                SharedPreferences.Editor preferencesEditor = settings.edit();
-                preferencesEditor.putString(Constants.PREFERENCE_SITEMAP, "");
-                preferencesEditor.apply();
-                selectSitemap(openHABBaseUrl, true, true);
-                return true;
             case R.id.mainmenu_openhab_writetag:
                 Intent writeTagIntent = new Intent(this.getApplicationContext(), OpenHABWriteTagActivity.class);
                 // TODO: get current display page url, which? how? :-/

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
@@ -10,6 +10,7 @@
 package org.openhab.habdroid.ui;
 
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
@@ -94,6 +95,13 @@ public class OpenHABPreferencesActivity extends AppCompatActivity {
             final Preference themePreference = getPreferenceScreen().findPreference(Constants.PREFERENCE_THEME);
             final Preference clearCachePreference = getPreferenceScreen().findPreference(Constants
                     .PREFERENCE_CLEAR_CACHE);
+            final Preference clearDefaultSitemapPreference = getPreferenceScreen().findPreference
+                    (Constants.PREFERENCE_CLEAR_DEFAULT_SITEMAP);
+
+            if (clearCachePreference.getSharedPreferences().getString(Constants
+                    .PREFERENCE_SITEMAP, "").isEmpty()) {
+                onNoDefaultSitemap(clearDefaultSitemapPreference);
+            }
 
             updateSslClientCertSummary(sslClientCert);
 
@@ -170,10 +178,28 @@ public class OpenHABPreferencesActivity extends AppCompatActivity {
                     return true;
                 }
             });
+
+            clearDefaultSitemapPreference.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    SharedPreferences.Editor edit = preference.getSharedPreferences().edit();
+                    edit.putString(Constants.PREFERENCE_SITEMAP, "");
+                    edit.apply();
+
+                    onNoDefaultSitemap(preference);
+                    return true;
+                }
+            });
+
             //fullscreen is not supoorted in builds < 4.4
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
                 getPreferenceScreen().removePreference(getPreferenceScreen().findPreference(Constants.PREFERENCE_FULLSCREEN));
             }
+        }
+
+        private void onNoDefaultSitemap(Preference pref) {
+            pref.setEnabled(false);
+            pref.setSummary(R.string.settings_no_default_sitemap);
         }
 
         private String getPreferenceString(Preference preference, String defValue) {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABPreferencesActivity.java
@@ -98,9 +98,12 @@ public class OpenHABPreferencesActivity extends AppCompatActivity {
             final Preference clearDefaultSitemapPreference = getPreferenceScreen().findPreference
                     (Constants.PREFERENCE_CLEAR_DEFAULT_SITEMAP);
 
-            if (clearCachePreference.getSharedPreferences().getString(Constants
-                    .PREFERENCE_SITEMAP, "").isEmpty()) {
+            String currentDefaultSitemap = clearDefaultSitemapPreference.getSharedPreferences().getString(Constants
+                    .PREFERENCE_SITEMAP, "");
+            if (currentDefaultSitemap.isEmpty()) {
                 onNoDefaultSitemap(clearDefaultSitemapPreference);
+            } else {
+                clearDefaultSitemapPreference.setSummary(getString(R.string.settings_current_default_sitemap, currentDefaultSitemap));
             }
 
             updateSslClientCertSummary(sslClientCert);

--- a/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
+++ b/mobile/src/main/java/org/openhab/habdroid/util/Constants.java
@@ -10,24 +10,27 @@
 package org.openhab.habdroid.util;
 
 public class Constants {
-    public static final String PREFERENCE_SCREENTIMEROFF    = "default_openhab_screentimeroff";
-    public static final String PREFERENCE_USERNAME          = "default_openhab_username";
-    public static final String PREFERENCE_PASSWORD          = "default_openhab_password";
-    public static final String PREFERENCE_SITEMAP           = "default_openhab_sitemap";
-    public static final String PREFERENCE_SSLCERT           = "default_openhab_sslcert";
-    public static final String PREFERENCE_SSLHOST           = "default_openhab_sslhost";
-    public static final String PREFERENCE_ALTURL            = "default_openhab_alturl";
-    public static final String PREFERENCE_URL               = "default_openhab_url";
-    public static final String PREFERENCE_THEME             = "default_openhab_theme";
-    public static final String PREFERENCE_ANIMATION         = "default_openhab_animation";
-    public static final String PREFERENCE_DEMOMODE          = "default_openhab_demomode";
-    public static final String PREFERENCE_FULLSCREEN        = "default_openhab_fullscreen";
-    public static final String PREFERENCE_TONE              = "default_openhab_alertringtone";
-    public static final String PREFERENCE_CLEAR_CACHE       = "default_openhab_cleacache";
-    public static final String PREFERENCE_SSLCLIENTCERT     = "default_openhab_sslclientcert";
-    public static final String PREFERENCE_SSLCLIENTCERT_HOWTO = "default_openhab_sslclientcert_howto";
-    public static final String PREFERENCE_DEBUG_MESSAGES      = "default_openhab_debug_messages";
-    public static final String DEFAULT_GCM_SENDER_ID          = "737820980945";
+    public static final String PREFERENCE_SCREENTIMEROFF        = "default_openhab_screentimeroff";
+    public static final String PREFERENCE_USERNAME              = "default_openhab_username";
+    public static final String PREFERENCE_PASSWORD              = "default_openhab_password";
+    public static final String PREFERENCE_SITEMAP               = "default_openhab_sitemap";
+    public static final String PREFERENCE_SSLCERT               = "default_openhab_sslcert";
+    public static final String PREFERENCE_SSLHOST               = "default_openhab_sslhost";
+    public static final String PREFERENCE_ALTURL                = "default_openhab_alturl";
+    public static final String PREFERENCE_URL                   = "default_openhab_url";
+    public static final String PREFERENCE_THEME                 = "default_openhab_theme";
+    public static final String PREFERENCE_ANIMATION             = "default_openhab_animation";
+    public static final String PREFERENCE_DEMOMODE              = "default_openhab_demomode";
+    public static final String PREFERENCE_FULLSCREEN            = "default_openhab_fullscreen";
+    public static final String PREFERENCE_TONE                  = "default_openhab_alertringtone";
+    public static final String PREFERENCE_CLEAR_CACHE           = "default_openhab_cleacache";
+    public static final String PREFERENCE_SSLCLIENTCERT         = "default_openhab_sslclientcert";
+    public static final String PREFERENCE_SSLCLIENTCERT_HOWTO   =
+            "default_openhab_sslclientcert_howto";
+    public static final String PREFERENCE_DEBUG_MESSAGES        = "default_openhab_debug_messages";
+    public static final String PREFERENCE_CLEAR_DEFAULT_SITEMAP =
+            "default_openhab_clear_default_sitemap";
+    public static final String DEFAULT_GCM_SENDER_ID            = "737820980945";
 
     public interface MESSAGES {
         public static final int DIALOG = 1;

--- a/mobile/src/main/res/menu/main_menu.xml
+++ b/mobile/src/main/res/menu/main_menu.xml
@@ -13,9 +13,4 @@
         android:orderInCategory="101"
         android:title="@string/mainmenu_openhab_writetag"
         app:showAsAction="never" />
-    <item
-        android:id="@+id/mainmenu_openhab_selectsitemap"
-        android:orderInCategory="102"
-        android:title="@string/mainmenu_openhab_selectsitemap"
-        app:showAsAction="never" />
 </menu>

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -136,7 +136,7 @@
     <string name="set">Setzen</string>
     <string name="cancel">Abbrechen</string>
     <string name="dlg_notification_title">Benachrichtigung</string>
-    <string name="settings_no_default_sitemap">Kein Standard-Sitemap festgelegt</string>
+    <string name="settings_no_default_sitemap">Keine Standard-Sitemap festgelegt</string>
     <string name="settings_clear_default_sitemap">Standard-Sitemap zurücksetzen</string>
-    <string name="settings_current_default_sitemap">Aktuelles Standard-Sitemap: %1$s</string>
+    <string name="settings_current_default_sitemap">Aktuelle Standard-Sitemap: %1$s</string>
 </resources>

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -136,4 +136,6 @@
     <string name="set">Setzen</string>
     <string name="cancel">Abbrechen</string>
     <string name="dlg_notification_title">Benachrichtigung</string>
+    <string name="settings_no_default_sitemap">Kein Standard-Sitemap festgelegt</string>
+    <string name="settings_clear_default_sitemap">Standard-Sitemap zurücksetzen</string>
 </resources>

--- a/mobile/src/main/res/values-de/strings.xml
+++ b/mobile/src/main/res/values-de/strings.xml
@@ -138,4 +138,5 @@
     <string name="dlg_notification_title">Benachrichtigung</string>
     <string name="settings_no_default_sitemap">Kein Standard-Sitemap festgelegt</string>
     <string name="settings_clear_default_sitemap">Standard-Sitemap zurücksetzen</string>
+    <string name="settings_current_default_sitemap">Aktuelles Standard-Sitemap: %1$s</string>
 </resources>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -50,6 +50,7 @@
     <string name="settings_ringtone">Ring tone</string>
     <string name="settings_clear_default_sitemap">Clear default sitemap</string>
     <string name="settings_no_default_sitemap">No default sitemap selected</string>
+    <string name="settings_current_default_sitemap">Current default sitemap: %1$s</string>
     <!-- App messages strings -->
     <string name="title_voice_widget">openHAB Voice Commands</string>
     <string name="info_voice_input">"openHAB, at your command!"</string>

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -48,6 +48,8 @@
     <string name="settings_openhab_icon_format_png">Bitmap</string>
     <string name="settings_openhab_icon_format_svg">Vector</string>
     <string name="settings_ringtone">Ring tone</string>
+    <string name="settings_clear_default_sitemap">Clear default sitemap</string>
+    <string name="settings_no_default_sitemap">No default sitemap selected</string>
     <!-- App messages strings -->
     <string name="title_voice_widget">openHAB Voice Commands</string>
     <string name="info_voice_input">"openHAB, at your command!"</string>

--- a/mobile/src/main/res/xml/preferences.xml
+++ b/mobile/src/main/res/xml/preferences.xml
@@ -56,6 +56,10 @@
             android:key="default_openhab_sslhost"
             android:summary="@string/settings_openhab_sslhost_summary"
             android:title="@string/settings_openhab_sslhost" />
+        <Preference
+            android:clickable="true"
+            android:key="default_openhab_clear_default_sitemap"
+            android:title="@string/settings_clear_default_sitemap" />
     </PreferenceCategory>
     <PreferenceCategory android:title="@string/settings_display_title">
         <ListPreference


### PR DESCRIPTION
Instead of a menu entry "Select default sitemap", there's now a setting in
the Preferences menu, which allows the user to "claer the default sitemap"
selection, if there's already a selection. Once cleared and going back to
the main activity, the user is prompted to select a new default sitemap.

Fixes #479