### PR TITLE
Re-introduce link to sitemap page for NFC write tag actions

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHABNFCActionList.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHABNFCActionList.java
@@ -9,13 +9,17 @@
 
 package org.openhab.habdroid.model;
 
+import android.content.Context;
+
+import org.openhab.habdroid.R;
+
 import java.util.ArrayList;
 
 public class OpenHABNFCActionList {
 	private ArrayList<String> actionNames;
 	private ArrayList<String> actionCommands;
 
-	public OpenHABNFCActionList(OpenHABWidget openHABWidget) {
+	public OpenHABNFCActionList(OpenHABWidget openHABWidget, Context ctx) {
 		actionNames = new ArrayList<String>();
 		actionCommands = new ArrayList<String>();
 		if (openHABWidget.getItem() != null) {
@@ -61,6 +65,7 @@ public class OpenHABNFCActionList {
 				}
 			}
 		}
+		actionNames.add(ctx.getString(R.string.nfc_action_to_sitemap_page));
 	}
 	
 	public String[] getNames() {

--- a/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
+++ b/mobile/src/main/java/org/openhab/habdroid/ui/OpenHABWidgetListFragment.java
@@ -178,30 +178,29 @@ public class OpenHABWidgetListFragment extends ListFragment {
                 Log.d(TAG, "Widget long-clicked " + String.valueOf(position));
                 OpenHABWidget openHABWidget = openHABWidgetAdapter.getItem(position);
                 Log.d(TAG, "Widget type = " + openHABWidget.getType());
-                if (openHABWidget.getType().equals("Switch") || openHABWidget.getType().equals("Selection") ||
-                        openHABWidget.getType().equals("Colorpicker")) {
-                    selectedOpenHABWidget = openHABWidget;
-                    AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
-                    builder.setTitle(R.string.nfc_dialog_title);
-                    OpenHABNFCActionList nfcActionList = new OpenHABNFCActionList(selectedOpenHABWidget);
-                    builder.setItems(nfcActionList.getNames(), new DialogInterface.OnClickListener() {
-                        public void onClick(DialogInterface dialog, int which) {
-                            Intent writeTagIntent = new Intent(getActivity().getApplicationContext(),
-                                    OpenHABWriteTagActivity.class);
-                            writeTagIntent.putExtra("sitemapPage", displayPageUrl);
+
+                selectedOpenHABWidget = openHABWidget;
+                AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+                builder.setTitle(R.string.nfc_dialog_title);
+                final OpenHABNFCActionList nfcActionList = new OpenHABNFCActionList
+                        (selectedOpenHABWidget, getContext());
+                builder.setItems(nfcActionList.getNames(), new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        Intent writeTagIntent = new Intent(getActivity().getApplicationContext(),
+                                OpenHABWriteTagActivity.class);
+                        writeTagIntent.putExtra("sitemapPage", displayPageUrl);
+
+                        if (nfcActionList.getCommands().length > which) {
                             writeTagIntent.putExtra("item", selectedOpenHABWidget.getItem().getName());
                             writeTagIntent.putExtra("itemType", selectedOpenHABWidget.getItem().getType());
-                            OpenHABNFCActionList nfcActionList =
-                                    new OpenHABNFCActionList(selectedOpenHABWidget);
                             writeTagIntent.putExtra("command", nfcActionList.getCommands()[which]);
-                            startActivityForResult(writeTagIntent, 0);
-                            Util.overridePendingTransition(getActivity(), false);
-                            selectedOpenHABWidget = null;
                         }
-                    });
-                    builder.show();
-                    return true;
-                }
+                        startActivityForResult(writeTagIntent, 0);
+                        Util.overridePendingTransition(getActivity(), false);
+                        selectedOpenHABWidget = null;
+                    }
+                });
+                builder.show();
                 return true;
             }
         });

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -128,6 +128,7 @@
     <string name="nfc_action_on">On</string>
     <string name="nfc_action_off">Off</string>
     <string name="nfc_action_toggle">Toggle</string>
+    <string name="nfc_action_to_sitemap_page">Navigate to Sitemap page</string>
 
     <!-- drawer -->
     <string name="drawer_open">Sitemap drawer opened</string>


### PR DESCRIPTION
The feature to create a NFC tag for a sitemap page is re-introduced with
this commit. However, it for now lifes in the long-press option of any
item on the current sitemap, instead of in the options menu.

Fixes #527