### PR TITLE
Enable pseudo translations for testing

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -27,6 +27,7 @@ android {
             minifyEnabled false
             buildConfigField 'boolean', IS_DEVELOPER, 'true'
             buildConfigField "java.util.Date", "buildTime", "new java.util.Date(" + System.currentTimeMillis() + "L)"
+            pseudoLocalesEnabled true
         }
     }
     productFlavors {


### PR DESCRIPTION
English (XA) and ... (XB) are pseudo translations for testing. This
changes will enable them in the app, when you switch the phone to one of
these languages.

https://androidbycode.wordpress.com/2015/04/19/pseudo-localization-testing-in-android/

Signed-off-by: mueller-ma <mueller-ma@users.noreply.github.com>