### PR TITLE
Improve english UI strings

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -10,7 +10,8 @@ source: https://github.com/openhab/openhab.android/blob/master/docs/USAGE.md
 
 # Android openHAB App
 
-The openHAB Android application is a native client for openHAB. The app follows the basic principles of the other UIs, like Basic UI, and presents your predefined openHAB [sitemap(s)](http://docs.openhab.org/configuration/sitemaps.html).
+The openHAB Android application is a native client for openHAB.
+The app follows the basic principles of the other openHAB UIs, like Basic UI, and presents your predefined openHAB [sitemap(s)](http://docs.openhab.org/configuration/sitemaps.html).
 
 <a href="https://play.google.com/store/apps/details?id=org.openhab.habdroid"><img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png" height="80"></a>
 
@@ -50,7 +51,7 @@ There are a number of strategies available to provide [secure remote access]({{b
 
 ## Permanent Deployment
 
-If you want to use openHAB Android on a wall mounted tablet, go to settings and tick `Disable display timer` and `Full Screen`.
+If you want to use openHAB Android on a wall mounted tablet, go to settings and tick `Disable display timer` and `Fullscreen`.
 
 ## Help and Technical Details
 

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -18,10 +18,10 @@
     <string name="settings_connection_title">Connection Settings</string>
     <string name="settings_display_title">Display Settings</string>
     <string name="settings_misc_title">Misc Settings</string>
-    <string name="settings_openhab_url">openHAB URL</string>
-    <string name="settings_openhab_url_summary">Manually configured openHAB URL. Disables autodiscovery if configured. [%s]</string>
-    <string name="settings_openhab_alturl">openHAB Remote URL</string>
-    <string name="settings_openhab_alturl_summary">Remote openHAB URL (used when local openHAB is unavailable) [%s]</string>
+    <string name="settings_openhab_url">Server address</string>
+    <string name="settings_openhab_url_summary">The hostname or IP address of the openHAB server. If configured, autodiscovery is disabled. Current setting: %s</string>
+    <string name="settings_openhab_alturl">Remote server address</string>
+    <string name="settings_openhab_alturl_summary">The URL or IP address of the openHAB server used when the local server address is unavailable. Current setting: %s</string>
     <string name="settings_openhab_username">Username</string>
     <string name="settings_openhab_password">Password</string>
     <string name="settings_openhab_sslclientcert">SSL client certificate</string>
@@ -32,12 +32,12 @@
     <string name="settings_openhab_screentimeroff_summary">Disable display switch off timer when openHAB is running</string>
     <string name="settings_openhab_demomode">Demo mode</string>
     <string name="settings_openhab_demomode_summary">Run in demo mode</string>
-    <string name="settings_openhab_theme">openHAB Theme</string>
+    <string name="settings_openhab_theme">Theme</string>
     <string name="settings_openhab_sslcert">Ignore SSL certificate</string>
     <string name="settings_openhab_sslcert_summary">Ignore certificate validation during SSL handshake</string>
     <string name="settings_openhab_sslhost">Ignore SSL hostname</string>
     <string name="settings_openhab_sslhost_summary">Ignore hostname check during SSL handshake</string>
-    <string name="settings_openhab_fullscreen">Full Screen</string>
+    <string name="settings_openhab_fullscreen">Fullscreen</string>
     <string name="settings_openhab_fullscreen_summary">Display in fullscreen mode</string>
     <string name="settings_openhab_icon_format">Icon format</string>
     <string name="settings_openhab_icon_format_value_png" translatable="false">PNG</string>
@@ -102,7 +102,7 @@
     <string name="info_openhab_gcm_not_connected">Device registration failed</string>
     <string name="info_openhab_gcm_connected">Registered device with Sender ID %s</string>
     <string name="action_settings">Settings</string>
-    <string name="nfc_dialog_title">Please select NFC tag action</string>
+    <string name="nfc_dialog_title">Write NFC tag action for this element</string>
     <string name="info_not_set">Not set</string>
     <string name="password_placeholder" translatable="false">\u25cf\u25cf\u25cf\u25cf\u25cf\u25cf</string>
     <!-- Strings for MemorizingTrustManager activity -->

--- a/mobile/src/main/res/values/strings.xml
+++ b/mobile/src/main/res/values/strings.xml
@@ -18,10 +18,10 @@
     <string name="settings_connection_title">Connection Settings</string>
     <string name="settings_display_title">Display Settings</string>
     <string name="settings_misc_title">Misc Settings</string>
-    <string name="settings_openhab_url">Server address</string>
-    <string name="settings_openhab_url_summary">The hostname or IP address of the openHAB server. If configured, autodiscovery is disabled. Current setting: %s</string>
-    <string name="settings_openhab_alturl">Remote server address</string>
-    <string name="settings_openhab_alturl_summary">The URL or IP address of the openHAB server used when the local server address is unavailable. Current setting: %s</string>
+    <string name="settings_openhab_url">Local server URL</string>
+    <string name="settings_openhab_url_summary">The URL of the openHAB dashboard (based on hostname or IP). If configured, autodiscovery is disabled. Current setting: %s</string>
+    <string name="settings_openhab_alturl">Remote server URL</string>
+    <string name="settings_openhab_alturl_summary">The URL of the openHAB dashboard used when the local address is unavailable. Current setting: %s</string>
     <string name="settings_openhab_username">Username</string>
     <string name="settings_openhab_password">Password</string>
     <string name="settings_openhab_sslclientcert">SSL client certificate</string>


### PR DESCRIPTION
A few suggestions after testing the new release.

* In the settings menu the same capitalization is used.
* Normalize the use of "Full Screen" vs. "Fullscreen" @digitaldan [which version](https://english.stackexchange.com/questions/162421/fullscreen-or-full-screen) do you prefer?
* Remove redundant "openHAB"
* When long-pressing an element, the "Please select NFC tag action comes as a surprise because a new user won't know about that function. I've adapted the string to better introduce it. Ideally an new menu entry should be added to the hamburger menu ("Write to NFC") explaining this function. 

This PR is just a **first suggestion**! Feel free to comment or adapt.

Signed-off-by: Thomas Dietrich <thomas.dietrich@tu-ilmenau.de> (github: ThomDietrich)