### PR TITLE
Fix icon for rollershutter

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Widget.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Widget.java
@@ -40,7 +40,8 @@ public class OpenHAB2Widget extends OpenHABWidget {
                         itemState = "OFF";
                     }
                 }
-            } else if(getType().equals("Switch") && ! hasMappings()) {
+            } else if(getType().equals("Switch") && ! hasMappings() &&
+                    (! widgetItem.getType().equals("Rollershutter") || (widgetItem.getGroupType() != null && widgetItem.getGroupType().equals("Rollershutter")))) {
                 // For switch items without mappings (just ON and OFF) that control a dimmer item
                 // set the state to "OFF" instead of 0 or to "ON" to fetch the correct icon
                 try {

--- a/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Widget.java
+++ b/mobile/src/main/java/org/openhab/habdroid/model/OpenHAB2Widget.java
@@ -41,7 +41,7 @@ public class OpenHAB2Widget extends OpenHABWidget {
                     }
                 }
             } else if(getType().equals("Switch") && ! hasMappings() &&
-                    (! widgetItem.getType().equals("Rollershutter") || (widgetItem.getGroupType() != null && widgetItem.getGroupType().equals("Rollershutter")))) {
+                    ! (widgetItem.getType().equals("Rollershutter") || (widgetItem.getGroupType() != null && widgetItem.getGroupType().equals("Rollershutter")))) {
                 // For switch items without mappings (just ON and OFF) that control a dimmer item
                 // set the state to "OFF" instead of 0 or to "ON" to fetch the correct icon
                 try {


### PR DESCRIPTION
See https://community.openhab.org/t/openhab-android-habdriod-december-2017-version-rollershutter-status-not-shown-correctly-anymore/37436