### PR TITLE
Make toast default

### DIFF
--- a/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
+++ b/mobile/src/main/java/org/openhab/habdroid/core/OpenHABVoiceService.java
@@ -133,11 +133,9 @@ public class OpenHABVoiceService extends ContinuingIntentService implements Open
                 AlertDialog alert = builder.create();
                 alert.show();
                 break;
-            case Constants.MESSAGES.TOAST:
+            default:
                 Toast.makeText(getApplicationContext(), message, Toast.LENGTH_LONG).show();
                 break;
-            default:
-                throw new IllegalArgumentException("Message type not implemented");
         }
     }
 


### PR DESCRIPTION
Fix #548 
Instead of crashing, because snackbar is not implemented here, fall back to toast. Snackbars are not available here, since they must be attached to a parent layout, which doesnt exist, when the user is on the home screen and uses the voice widget.